### PR TITLE
libtypec: Expand VDO decoding, add header file for lstypec

### DIFF
--- a/libtypec.h
+++ b/libtypec.h
@@ -34,6 +34,8 @@ SOFTWARE.
 #ifndef LIBTYPEC_H
 #define LIBTYPEC_H
 
+#include <stdint.h>
+
 struct libtypec_capabiliy_data
 {
     unsigned int bmAttributes;
@@ -58,8 +60,8 @@ struct libtypec_connector_cap_data
     unsigned swap2snk : 1;
     unsigned reserved : 2;
     unsigned reservedmsb : 12;
-    unsigned port_rev : 2;
-    unsigned plug_rev : 2;
+    unsigned partner_rev : 8;
+    unsigned cable_rev : 8;
 };
 
 struct altmode_data
@@ -73,12 +75,12 @@ union libtypec_discovered_identity
     char buf_disc_id[24];
     struct discovered_identity
     {
-        unsigned long cert_stat;
-        unsigned long id_header;
-        unsigned long product;
-        unsigned long product_type_vdo1;
-        unsigned long product_type_vdo2;
-        unsigned long product_type_vdo3;
+        uint32_t cert_stat;
+        uint32_t id_header;
+        uint32_t product;
+        uint32_t product_type_vdo1;
+        uint32_t product_type_vdo2;
+        uint32_t product_type_vdo3;
     } disc_id;
 };
 

--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -121,6 +121,25 @@ static short get_bcd_from_rev_file(char *path)
 	}
 	return bcd;
 }
+
+static char get_pd_rev(char *path)
+{
+	char buf[10];
+	char rev = 0;
+
+	FILE *fp = fopen(path, "r");
+
+	if (fp)
+	{
+		fgets(buf, 10, fp);
+
+		rev = ((buf[0] - '0') << 4) | (buf[2] - '0');
+
+		fclose(fp);
+	}
+	return rev;
+}
+
 static int get_cable_plug_type(char *path)
 {
 	char buf[64];
@@ -303,11 +322,11 @@ static int libtypec_sysfs_get_conn_capability_ops(int conn_num, struct libtypec_
 	{
 		sprintf(port_content, "%s/port%d-partner/%s", path_str, conn_num, "usb_power_delivery_revision");
 
-		conn_cap_data->port_rev = (get_bcd_from_rev_file(port_content) >> 8) & 0xFF;
+		conn_cap_data->partner_rev = get_pd_rev(port_content);
 
 		sprintf(port_content, "%s/port%d-cable/%s", path_str, conn_num, "usb_power_delivery_revision");
 
-		conn_cap_data->plug_rev = (get_bcd_from_rev_file(port_content) >> 8) & 0xFF;
+		conn_cap_data->cable_rev = get_pd_rev(port_content);
 	}
 	return 0;
 }

--- a/utils/lstypec.c
+++ b/utils/lstypec.c
@@ -16,17 +16,17 @@
 /**
  * @file lstypec.c
  * @author Rajaram Regupathy <rajaram.regupathy@gmail.com>
+ * @coauthor Jameson Thies <jthies@google.com>
  * @brief Implements listing of typec port and port partner details
  *
  */
 
 #include <stdio.h>
 #include "../libtypec.h"
+#include "lstypec.h"
 #include "names.h"
 #include <stdlib.h>
-
-#define LSTYPEC_MAJOR_VERSION 0
-#define LSTYPEC_MINOR_VERSION 1
+#include <stdint.h>
 
 struct libtypec_capabiliy_data get_cap_data;
 struct libtypec_connector_cap_data conn_data;
@@ -36,96 +36,143 @@ union libtypec_discovered_identity id;
 
 struct altmode_data am_data[64];
 char *session_info[LIBTYPEC_SESSION_MAX_INDEX];
-
-#define LSTYPEC_ERROR 1
-#define LSTYPEC_INFO 2
-
 int verbose = 1;
 
-union id_header
+enum product_type get_cable_product_type(short rev, uint32_t id)
 {
-    unsigned long id_hdr;
-    struct
-    {
-        unsigned usb_vendor_id : 16;
-        unsigned reserved : 5;
-        unsigned connector_type : 2;
-        unsigned prd_type_dfp : 3;
-        unsigned modal_operation : 1;
-        unsigned product_type : 3;
-        unsigned usb_capable_device : 1;
-        unsigned usb_capable_host : 1;
-    } id_hdr_pd3_1_v1_3;
+  // Decode cable product type
+  if (rev == 0x20)
+  {
+    // USB PD 2.0 cable
+    if ((id & pd_ufp_product_type_mask) == pd2p0_passive_cable)
+      return product_type_pd2p0_passive_cable;
+    else if ((id & pd_ufp_product_type_mask) == pd2p0_active_cable)
+      return product_type_pd2p0_active_cable;
+    else
+      return product_type_other;
+  }
+  else if (rev == 0x30)
+  {
+    // USB PD 3.0 cable
+    if ((id & pd_ufp_product_type_mask) == pd3p0_passive_cable)
+      return product_type_pd3p0_passive_cable;
+    else if ((id & pd_ufp_product_type_mask) == pd3p0_active_cable)
+      return product_type_pd3p0_active_cable;
+    else
+      return product_type_other;
+  }
+  else if (rev == 0x31)
+  {
+    // USB PD 3.1 cable
+    if ((id & pd_ufp_product_type_mask) == pd3p1_passive_cable)
+      return product_type_pd3p1_passive_cable;
+    else if ((id & pd_ufp_product_type_mask) == pd3p1_active_cable)
+      return product_type_pd3p1_active_cable;
+    else if ((id & pd_ufp_product_type_mask) == pd3p1_vpd)
+      return product_type_pd3p1_vpd;
+    else
+      return product_type_other;
+  }
+  return product_type_other;
+}
 
-    struct
-    {
-        unsigned usb_vendor_id : 16;
-        unsigned reserved : 10;
-        unsigned modal_operation : 1;
-        unsigned product_type : 3;
-        unsigned usb_capable_device : 1;
-        unsigned usb_capable_host : 1;
-    } id_hdr_pd2_v1_3;
-};
-
-union passive_vdo_1
+enum product_type get_partner_product_type(short rev, uint32_t id)
 {
+  // Decode partner product type
+  if (rev == 0x20)
+  {
+    // USB PD 2.0 partner
+    if ((id & pd_ufp_product_type_mask) == pd2p0_ama)
+      return product_type_pd2p0_ama;
+    else
+      return product_type_other;
+  }
+  else if (rev == 0x30)
+  {
+    // USB PD 3.0 partner
+    char ufp_supported = 0;
+    if ((id & pd_ufp_product_type_mask) == pd3p0_hub)
+      ufp_supported = 1;
+    else if ((id & pd_ufp_product_type_mask) == pd3p0_peripheral)
+      ufp_supported = 1;
+    else if ((id & pd_ufp_product_type_mask) == pd3p0_ama)
+      return product_type_pd3p0_ama;
+    else if ((id & pd_ufp_product_type_mask) == pd3p0_vpd)
+      return product_type_pd3p0_vpd;
 
-    unsigned long psv_vdo_1;
+    char dfp_supported = 0;
+    if ((id & pd_dfp_product_type_mask) == pd3p0_dfp_hub)
+      ufp_supported = 1;
+    else if ((id & pd_dfp_product_type_mask) == pd3p0_dfp_host)
+      ufp_supported = 1;
+    else if ((id & pd_dfp_product_type_mask) == pd3p0_power_brick)
+      ufp_supported = 1;
 
-    struct
-    {
-        unsigned usb_signalling : 3;
-        unsigned reserved3 : 2;
-        unsigned vbus_current_cap : 2;
-        unsigned reserved7 : 2;
-        unsigned vbus_max_volt : 2;
-        unsigned termination_type : 2;
-        unsigned latency : 4;
-        unsigned epr_mode : 1;
-        unsigned plug_type : 2;
-        unsigned reserved20 : 1;
-        unsigned vdo_version : 3;
-        unsigned fw_ver : 4;
-        unsigned hw_ver : 4;
-    } psv_vdo1_pd3_1_v1_3;
+    if (ufp_supported && dfp_supported)
+      return product_type_pd3p0_drd;
+    else if (ufp_supported)
+      return product_type_pd3p0_ufp;
+    else if (dfp_supported)
+      return product_type_pd3p0_dfp;
+    else
+      return product_type_other;
+  }
+  else if (rev == 0x31)
+  {
+    // USB PD 3.1 partner
+    char ufp_supported = 0;
+    if ((id & pd_ufp_product_type_mask) == pd3p1_hub)
+      ufp_supported = 1;
+    else if ((id & pd_ufp_product_type_mask) == pd3p1_peripheral)
+      ufp_supported = 1;
 
-    struct
-    {
-        unsigned usb_signalling : 3;
-        unsigned reserved3 : 1;
-        unsigned vbus_thru_cbl : 1;
-        unsigned vbus_handling : 2;
-        unsigned dir_support : 4;
-        unsigned termination_type : 2;
-        unsigned latency : 4;
-        unsigned reserved17 : 1;
-        unsigned plug_type : 2;
-        unsigned reserved20 : 4;
-        unsigned fw_ver : 4;
-        unsigned hw_ver : 4;
-    } psv_vdo1_pd2_v1_3;
-};
+    char dfp_supported = 0;
+    if ((id & pd_dfp_product_type_mask) == pd3p1_dfp_hub)
+      ufp_supported = 1;
+    else if ((id & pd_dfp_product_type_mask) == pd3p1_dfp_host)
+      ufp_supported = 1;
+    else if ((id & pd_dfp_product_type_mask) == pd3p1_power_brick)
+      ufp_supported = 1;
+
+    if (ufp_supported && dfp_supported)
+      return product_type_pd3p1_drd;
+    else if (ufp_supported)
+      return product_type_pd3p1_ufp;
+    else if (dfp_supported)
+      return product_type_pd3p1_dfp;
+    else
+      return product_type_other;
+  }
+  return product_type_other;
+}
+
+void print_vdo(uint32_t vdo, int num_fields, struct vdo_field vdo_fields[], char *vdo_field_desc[][MAX_FIELDS])
+{
+  for (int i = 0; i < num_fields; i++){
+    if(!vdo_fields[i].print)
+      continue;
+
+    if(vdo_field_desc[i][0] != NULL)
+       printf("\t\t\t%s\t:\t%s\n", vdo_fields[i].name, vdo_field_desc[i][((vdo >> vdo_fields[i].index) & vdo_fields[i].mask)]);
+    else
+       printf("\t\t\t%s\t:\t0x%0x\n", vdo_fields[i].name, ((vdo >> vdo_fields[i].index) & vdo_fields[i].mask));
+
+  }
+}
 
 void print_session_info()
 {
     printf("lstypec %d.%d Session Info\n", LSTYPEC_MAJOR_VERSION, LSTYPEC_MINOR_VERSION);
-
     printf("\tUsing %s\n", session_info[LIBTYPEC_VERSION_INDEX]);
-
     printf("\t%s with Kernel %s\n", session_info[LIBTYPEC_OS_INDEX], session_info[LIBTYPEC_KERNEL_INDEX]);
 }
 
 void print_ppm_capability(struct libtypec_capabiliy_data ppm_data)
 {
     printf("\nUSB-C Platform Policy Manager Capability\n");
-
     printf("\tNumber of Connectors:\t\t%d\n", ppm_data.bNumConnectors);
-
     printf("\tNumber of Alternate Modes:\t%d\n", ppm_data.bNumAltModes);
-
     printf("\tUSB Power Delivery Revision:\t%d.%d\n", (ppm_data.bcdPDVersion >> 8) & 0XFF, (ppm_data.bcdPDVersion) & 0XFF);
-
     printf("\tUSB Type-C Revision:\t\t%d.%d\n", (ppm_data.bcdTypeCVersion >> 8) & 0XFF, (ppm_data.bcdTypeCVersion) & 0XFF);
 }
 
@@ -142,219 +189,288 @@ void print_cable_prop(struct libtypec_cable_property cable_prop, int conn_num)
     char *cable_plug_type[] = {"USB Type A", "USB Type B", "USB Type C", "Non-USB Type", "Unknown"};
 
     printf("\tCable Property in Port %d:\n", conn_num);
-
     printf("\t\tCable Type\t:\t%s\n", cable_type[cable_prop.cable_type]);
-
     printf("\t\tCable Plug Type\t:\t%s\n", cable_plug_type[cable_prop.plug_end_type]);
 }
 
-void print_alternate_mode_data(int recepient, int num_mode, struct altmode_data *am_data)
+void print_alternate_mode_data(int recipient, int num_mode, struct altmode_data *am_data)
 {
 
-    if (recepient == AM_CONNECTOR)
+    if (recipient == AM_CONNECTOR)
     {
-
         for (int i = 0; i < num_mode; i++)
         {
-
             printf("\tLocal Modes %d:\n", i);
-
             printf("\t\tSVID\t:\t0x%04lx\n", am_data[i].svid);
-
             printf("\t\tVDO\t:\t0x%04lx\n", am_data[i].vdo);
         }
     }
 
-    if (recepient == AM_SOP)
+    if (recipient == AM_SOP)
     {
-
         for (int i = 0; i < num_mode; i++)
         {
-
             printf("\tPartner Modes %d:\n", i);
-
             printf("\t\tSVID\t:\t0x%04lx\n", am_data[i].svid);
-
             printf("\t\tVDO\t:\t0x%04lx\n", am_data[i].vdo);
         }
     }
 
-    if (recepient == AM_SOP_PR)
+    if (recipient == AM_SOP_PR)
     {
-
         for (int i = 0; i < num_mode; i++)
         {
-
             printf("\tCable Plug Modes %d:\n", i);
-
             printf("\t\tSVID\t:\t0x%04lx\n", am_data[i].svid);
-
             printf("\t\tVDO\t:\t0x%04lx\n", am_data[i].vdo);
         }
     }
 }
 
-void print_identity_data(int recepient, union libtypec_discovered_identity id)
+void print_identity_data(int recipient, union libtypec_discovered_identity id)
 {
-    char *conn_type[] = {"Legacy systems", "Undefined", "USB Type-C Receptacle", "USB Type-C Plug"};
-    char *dfp_type[] = {"Not a DFP/Legacy Device", "PDUSB Hub", "PDUSB Host", "Power Brick", "Alternate Mode Adaptor", "Reserved"};
-    char *ufp_type[] = {"Not a UFP", "PDUSB Hub", "PDUSB Peripheral", "PSD", "Reserved", "Alternate Mode Adapter", "VConn Powered Device", "Reserved"};
-    char *cbl_type[] = {"Not a Cable Plug/VPD", "Reserved", "Reserved", "Passive Cable", "Active Cable", "Reserved"};
-    char *latency[] = {"<10ns (~1m)", "10ns to 20ns (~2m)", "20ns to 30ns (~3m)",
-                       "30ns to 40ns (~4m)", "40ns to 50ns (~5m)", "50ns to 60ns (~6m)",
-                       "60ns to 70ns (~7m)", "> 70ns (>~7m)", "Reserved"};
-    char *vbus_max_volt[] = {"20V", "Deprecated", "Deprecated", "50V"};
-    char *vbus_cur_handling[] = {"Reserved", "3A", "5A", "Reserved"};
-    char *usb_speed_v3[] = {"USB 2.0", "USB 3.2 Gen1", "USB 3.2/USB4 Gen 2", "USB4 Gen3"};
-    char *usb_speed_v2[] = {"USB 2.0", "USB 3.1 Gen1", "USB 3.1 Gen1 Gen 2", "Reserved"};
-    char *plug_type_v2[] = {"USB Type-A", "USB Type-B", "USB Type-C", "Captive"};
-    char vendor_id[128];
+  char vendor_id[128];
+  union id_header id_hdr_val;
+  id_hdr_val.id_hdr = id.disc_id.id_header;
 
-    if (recepient == AM_SOP)
+  if (recipient == AM_SOP)
+  {
+    printf("\tPartner Identity :\n");
+
+    // Partner ID
+    if (verbose)
     {
-        printf("\tPartner Identity :\n");
+      // ID Header/Cert Stat/Product are base on revision
+      switch (conn_data.partner_rev)
+      {
+        case 0x20:
+          printf("\t\tID Header\t:\t0x%08lx\n", id.disc_id.id_header);
+          get_vendor_string(vendor_id, sizeof(vendor_id), id_hdr_val.id_hdr_pd2p0.usb_vendor_id);
+          print_vdo(((uint32_t) id.disc_id.id_header), 6, pd2p0_partner_id_header_fields, pd2p0_partner_id_header_field_desc);
+          printf("\t\t\tDecoded VID\t:\t0x%04x (%s)\n", id_hdr_val.id_hdr_pd2p0.usb_vendor_id, (vendor_id == NULL ? "unknown" : vendor_id));
+          printf("\t\tCert Stat\t:\t0x%08lx\n", id.disc_id.cert_stat);
+          print_vdo(((uint32_t) id.disc_id.cert_stat), 1, pd2p0_cert_stat_fields, pd2p0_cert_stat_field_desc);
+          printf("\t\tProduct\t\t:\t0x%08lx\n", id.disc_id.product);
+          print_vdo(((uint32_t) id.disc_id.product), 2, pd2p0_product_fields, pd2p0_product_field_desc);
+          break;
+        case 0x30:
+          printf("\t\tID Header\t:\t0x%08lx\n", id.disc_id.id_header);
+          get_vendor_string(vendor_id, sizeof(vendor_id), id_hdr_val.id_hdr_pd3p0.usb_vendor_id);
+          print_vdo(((uint32_t) id.disc_id.id_header), 7, pd3p0_partner_id_header_fields, pd3p0_partner_id_header_field_desc);
+          printf("\t\t\tDecoded VID\t:\t0x%04x (%s)\n", id_hdr_val.id_hdr_pd3p0.usb_vendor_id, (vendor_id == NULL ? "unknown" : vendor_id));
+          printf("\t\tCert Stat\t:\t0x%08lx\n", id.disc_id.cert_stat);
+          print_vdo(((uint32_t) id.disc_id.cert_stat), 1, pd3p0_cert_stat_fields, pd3p0_cert_stat_field_desc);
+          printf("\t\tProduct\t\t:\t0x%08lx\n", id.disc_id.product);
+          print_vdo(((uint32_t) id.disc_id.product), 2, pd3p0_product_fields, pd3p0_product_field_desc);
+          break;
+        case 0x31:
+          printf("\t\tID Header\t:\t0x%08lx\n", id.disc_id.id_header);
+          get_vendor_string(vendor_id, sizeof(vendor_id), id_hdr_val.id_hdr_pd3p1.usb_vendor_id);
+          print_vdo(((uint32_t) id.disc_id.id_header), 8, pd3p1_partner_id_header_fields, pd3p1_partner_id_header_field_desc);
+          printf("\t\t\tDecoded VID\t:\t0x%04x (%s)\n", id_hdr_val.id_hdr_pd3p1.usb_vendor_id, (vendor_id == NULL ? "unknown" : vendor_id));
+          printf("\t\tCert Stat\t:\t0x%08lx\n", id.disc_id.cert_stat);
+          print_vdo(((uint32_t) id.disc_id.cert_stat), 1, pd3p1_cert_stat_fields, pd3p1_cert_stat_field_desc);
+          printf("\t\tProduct\t\t:\t0x%08lx\n", id.disc_id.product);
+          print_vdo(((uint32_t) id.disc_id.product), 2, pd3p1_product_fields, pd3p1_product_field_desc);
+          break;
+        default:
+          printf("\t\tID Header\t:\t0x%08lx\n", id.disc_id.id_header);
+          printf("\t\tCert Stat\t:\t0x%08lx\n", id.disc_id.cert_stat);
+          printf("\t\tProduct\t\t:\t0x%08lx\n", id.disc_id.product);
+          break;
+      }
 
-        printf("\t\tCertificate\t:\t0x%04lx\n", id.disc_id.cert_stat);
-
-        printf("\t\tID Header\t:\t0x%04lx\n", id.disc_id.id_header);
-
-        if (verbose)
-        {
-            union id_header id_hdr_val;
-            id_hdr_val.id_hdr = id.disc_id.id_header;
-
-            get_vendor_string(vendor_id, sizeof(vendor_id), id_hdr_val.id_hdr_pd3_1_v1_3.usb_vendor_id);
-
-            printf("\t\t\tVendor ID\t\t:\t0x%04x (%s)\n", id_hdr_val.id_hdr_pd3_1_v1_3.usb_vendor_id, vendor_id);
-
-            printf("\t\t\tConnector Type\t\t:\t%d(%s)\n", id_hdr_val.id_hdr_pd3_1_v1_3.connector_type, conn_type[id_hdr_val.id_hdr_pd3_1_v1_3.connector_type]);
-
-            printf("\t\t\tDFP Product Type\t:\t%d(%s)\n", id_hdr_val.id_hdr_pd3_1_v1_3.prd_type_dfp, dfp_type[id_hdr_val.id_hdr_pd3_1_v1_3.prd_type_dfp]);
-
-            printf("\t\t\tModal Operation\t\t:\t%s\n", id_hdr_val.id_hdr_pd3_1_v1_3.modal_operation ? "Yes" : "No");
-
-            printf("\t\t\tUFP Product Type\t:\t%d(%s)\n", id_hdr_val.id_hdr_pd3_1_v1_3.product_type, ufp_type[id_hdr_val.id_hdr_pd3_1_v1_3.product_type]);
-
-            printf("\t\t\tUSB Device Capability\t:\t%s\n", id_hdr_val.id_hdr_pd3_1_v1_3.usb_capable_device ? "Yes" : "No");
-
-            printf("\t\t\tUSB Host Capability\t:\t%s\n", id_hdr_val.id_hdr_pd3_1_v1_3.usb_capable_host ? "Yes" : "No");
-        }
-
-        printf("\t\tProduct\t\t:\t0x%04lx\n", id.disc_id.product);
-
-        if (verbose)
-        {
-
-            printf("\t\t\tUSB Product ID\t\t:\t0x%04lx\n", (id.disc_id.product >> 16) & 0xffff);
-
-            printf("\t\t\tbcdDevice\t\t:\t0x%04lx\n", id.disc_id.product & 0xFFFF);
-        }
-
-        printf("\t\tProduct VDO 1\t:\t0x%04lx\n", id.disc_id.product_type_vdo1);
-
-        printf("\t\tProduct VDO 2\t:\t0x%04lx\n", id.disc_id.product_type_vdo2);
-
-        printf("\t\tProduct VDO 3\t:\t0x%04lx\n", id.disc_id.product_type_vdo3);
+      //Product Type VDOs based on product type
+      enum product_type partner_product_type = get_partner_product_type(conn_data.partner_rev, ((uint32_t) id.disc_id.id_header));
+      switch (partner_product_type)
+      {
+        case product_type_pd2p0_ama:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 11, pd2p0_ama_fields, pd2p0_ama_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+        case product_type_pd3p0_ama:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 8, pd3p0_ama_fields, pd3p0_ama_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+        case product_type_pd3p0_vpd:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 10, pd3p0_vpd_fields, pd3p0_vpd_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+        case product_type_pd3p0_ufp:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 6, pd3p0_ufp_vdo1_fields, pd3p0_ufp_vdo1_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo2), 6, pd3p0_ufp_vdo2_fields, pd3p0_ufp_vdo2_field_desc);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+        case product_type_pd3p0_dfp:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 5, pd3p0_dfp_fields, pd3p0_dfp_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+        case product_type_pd3p0_drd:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 6, pd3p0_ufp_vdo1_fields, pd3p0_ufp_vdo1_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo2), 6, pd3p0_ufp_vdo2_fields, pd3p0_ufp_vdo2_field_desc);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo3), 5, pd3p0_dfp_fields, pd3p0_dfp_field_desc);
+          break;
+        case product_type_pd3p1_ufp:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 10, pd3p1_ufp_fields, pd3p1_ufp_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+        case product_type_pd3p1_dfp:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 6, pd3p1_dfp_fields, pd3p1_dfp_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+        case product_type_pd3p1_drd:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 10, pd3p1_ufp_fields, pd3p1_ufp_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo3), 6, pd3p1_dfp_fields, pd3p1_dfp_field_desc);
+        default:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+      }
     }
-
-    if (recepient == AM_SOP_PR)
+    else
     {
-
-        printf("\tCable Identity :\n");
-
-        printf("\t\tCertificate\t:\t0x%04lx\n", id.disc_id.cert_stat);
-
-        printf("\t\tID Header\t:\t0x%04lx\n", id.disc_id.id_header);
-
-        if (verbose)
-        {
-            union id_header id_hdr_val;
-
-            id_hdr_val.id_hdr = id.disc_id.id_header;
-
-            get_vendor_string(vendor_id, sizeof(vendor_id), id_hdr_val.id_hdr_pd3_1_v1_3.usb_vendor_id);
-
-            printf("\t\t\tVendor ID\t\t:\t0x%04x (%s)\n", id_hdr_val.id_hdr_pd3_1_v1_3.usb_vendor_id, vendor_id);
-
-            printf("\t\t\tConnector Type\t\t:\t%d(%s)\n", id_hdr_val.id_hdr_pd3_1_v1_3.connector_type, conn_type[id_hdr_val.id_hdr_pd3_1_v1_3.connector_type]);
-
-            printf("\t\t\tDFP Product Type\t:\t%d(%s)\n", id_hdr_val.id_hdr_pd3_1_v1_3.prd_type_dfp, dfp_type[id_hdr_val.id_hdr_pd3_1_v1_3.prd_type_dfp]);
-
-            printf("\t\t\tModal Operation\t\t:\t%s\n", id_hdr_val.id_hdr_pd3_1_v1_3.modal_operation ? "Yes" : "No");
-
-            printf("\t\t\tUFP Product Type\t:\t%d(%s)\n", id_hdr_val.id_hdr_pd3_1_v1_3.product_type, cbl_type[id_hdr_val.id_hdr_pd3_1_v1_3.product_type]);
-
-            printf("\t\t\tUSB Device Capability\t:\t%s\n", id_hdr_val.id_hdr_pd3_1_v1_3.usb_capable_device ? "Yes" : "No");
-
-            printf("\t\t\tUSB Host Capability\t:\t%s\n", id_hdr_val.id_hdr_pd3_1_v1_3.usb_capable_host ? "Yes" : "No");
-        }
-
-        printf("\t\tProduct\t\t:\t0x%04lx\n", id.disc_id.product);
-
-        if (verbose)
-        {
-
-            printf("\t\t\tUSB Product ID\t\t:\t0x%04lx\n", (id.disc_id.product >> 16) & 0xffff);
-
-            printf("\t\t\tbcdDevice\t\t:\t0x%04lx\n", id.disc_id.product & 0xFFFF);
-        }
-
-        printf("\t\tProduct VDO 1\t:\t0x%04lx\n", id.disc_id.product_type_vdo1);
-
-        if (verbose)
-        {
-            union passive_vdo_1 psv_vdo1;
-
-            psv_vdo1.psv_vdo_1 = id.disc_id.product_type_vdo1;
-
-            if (conn_data.plug_rev == 2)
-            {
-                printf("\t\t\tHW Version\t:\t%d\n", psv_vdo1.psv_vdo1_pd2_v1_3.hw_ver);
-
-                printf("\t\t\tFW Version\t:\t%d\n", psv_vdo1.psv_vdo1_pd2_v1_3.fw_ver);
-
-                printf("\t\t\tPlug Type\t:\t%d(%s)\n", psv_vdo1.psv_vdo1_pd2_v1_3.plug_type, plug_type_v2[psv_vdo1.psv_vdo1_pd2_v1_3.plug_type]);
-
-                printf("\t\t\tCable Latency\t:\t%d(%s)\n", psv_vdo1.psv_vdo1_pd2_v1_3.latency, latency[psv_vdo1.psv_vdo1_pd2_v1_3.latency]);
-
-                printf("\t\t\tCable Termination\t:\t%d\n", psv_vdo1.psv_vdo1_pd2_v1_3.termination_type);
-
-                printf("\t\t\tDirection Support\t:\t%d\n", psv_vdo1.psv_vdo1_pd2_v1_3.dir_support);
-
-                printf("\t\t\tVBus Current Capacity\t:\t%d(%s)\n", psv_vdo1.psv_vdo1_pd2_v1_3.vbus_handling, vbus_cur_handling[psv_vdo1.psv_vdo1_pd2_v1_3.vbus_handling]);
-
-                printf("\t\t\tVBus Through Cable\t:\t%d\n", psv_vdo1.psv_vdo1_pd2_v1_3.vbus_thru_cbl);
-
-                printf("\t\t\tUSB Signalling Support\t:\t%d(%s)\n", psv_vdo1.psv_vdo1_pd2_v1_3.usb_signalling, usb_speed_v2[psv_vdo1.psv_vdo1_pd2_v1_3.usb_signalling]);
-            }
-            else
-            {
-                printf("\t\t\tHW Version\t:\t%d\n", psv_vdo1.psv_vdo1_pd3_1_v1_3.hw_ver);
-
-                printf("\t\t\tFW Version\t:\t%d\n", psv_vdo1.psv_vdo1_pd3_1_v1_3.fw_ver);
-
-                printf("\t\t\tVDO Version\t:\t%d\n", psv_vdo1.psv_vdo1_pd3_1_v1_3.vdo_version);
-
-                printf("\t\t\tPlug Type\t:\t%d(%s)\n", psv_vdo1.psv_vdo1_pd3_1_v1_3.plug_type, psv_vdo1.psv_vdo1_pd3_1_v1_3.plug_type == 2 ? "USB Type C" : "Captive");
-
-                printf("\t\t\tEPR Mode\t:\t%d\n", psv_vdo1.psv_vdo1_pd3_1_v1_3.epr_mode);
-
-                printf("\t\t\tCable Latency\t:\t%d(%s)\n", psv_vdo1.psv_vdo1_pd3_1_v1_3.latency, latency[psv_vdo1.psv_vdo1_pd3_1_v1_3.latency]);
-
-                printf("\t\t\tCable Termination\t:\t%d(%s)\n", psv_vdo1.psv_vdo1_pd3_1_v1_3.termination_type, psv_vdo1.psv_vdo1_pd3_1_v1_3.termination_type ? "VCONN not required" : "VCONN required");
-
-                printf("\t\t\tVBus Voltage Max\t:\t%d(%s)\n", psv_vdo1.psv_vdo1_pd3_1_v1_3.vbus_max_volt, vbus_max_volt[psv_vdo1.psv_vdo1_pd3_1_v1_3.vbus_max_volt]);
-
-                printf("\t\t\tVBus Current Capacity\t:\t%d(%s)\n", psv_vdo1.psv_vdo1_pd3_1_v1_3.vbus_current_cap, vbus_cur_handling[psv_vdo1.psv_vdo1_pd3_1_v1_3.vbus_current_cap]);
-
-                printf("\t\t\tUSB Highest Speed\t:\t%d(%s)\n", psv_vdo1.psv_vdo1_pd3_1_v1_3.usb_signalling, usb_speed_v3[psv_vdo1.psv_vdo1_pd3_1_v1_3.usb_signalling]);
-            }
-        }
-
-        printf("\t\tProduct VDO 2\t:\t0x%04lx\n", id.disc_id.product_type_vdo2);
-
-        printf("\t\tProduct VDO 3\t:\t0x%04lx\n", id.disc_id.product_type_vdo3);
+      printf("\t\tID Header\t:\t0x%08lx\n", id.disc_id.id_header);
+      printf("\t\tCert Stat\t:\t0x%08lx\n", id.disc_id.cert_stat);
+      printf("\t\tProduct\t\t:\t0x%08lx\n", id.disc_id.product);
+      printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+      printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+      printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
     }
+  }
+  else if (recipient == AM_SOP_PR)
+  {
+
+    printf("\tCable Identity :\n");
+
+    // Partner ID
+    if (verbose)
+    {
+      // ID Header/Cert Stat/Product are base on revision
+      switch (conn_data.cable_rev)
+      {
+        case 0x20:
+          printf("\t\tID Header\t:\t0x%08lx\n", id.disc_id.id_header);
+          get_vendor_string(vendor_id, sizeof(vendor_id), id_hdr_val.id_hdr_pd2p0.usb_vendor_id);
+          print_vdo(((uint32_t) id.disc_id.id_header), 6, pd2p0_cable_id_header_fields, pd2p0_cable_id_header_field_desc);
+          printf("\t\t\tDecoded VID\t:\t0x%04x (%s)\n", id_hdr_val.id_hdr_pd2p0.usb_vendor_id, (vendor_id == NULL ? "unknown" : vendor_id));
+          printf("\t\tCert Stat\t:\t0x%08lx\n", id.disc_id.cert_stat);
+          print_vdo(((uint32_t) id.disc_id.cert_stat), 1, pd2p0_cert_stat_fields, pd2p0_cert_stat_field_desc);
+          printf("\t\tProduct\t\t:\t0x%08lx\n", id.disc_id.product);
+          print_vdo(((uint32_t) id.disc_id.product), 2, pd2p0_product_fields, pd2p0_product_field_desc);
+          break;
+        case 0x30:
+          printf("\t\tID Header\t:\t0x%08lx\n", id.disc_id.id_header);
+          get_vendor_string(vendor_id, sizeof(vendor_id), id_hdr_val.id_hdr_pd3p0.usb_vendor_id);
+          print_vdo(((uint32_t) id.disc_id.id_header), 7, pd3p0_cable_id_header_fields, pd3p0_cable_id_header_field_desc);
+          printf("\t\t\tDecoded VID\t:\t0x%04x (%s)\n", id_hdr_val.id_hdr_pd3p0.usb_vendor_id, (vendor_id == NULL ? "unknown" : vendor_id));
+          printf("\t\tCert Stat\t:\t0x%08lx\n", id.disc_id.cert_stat);
+          print_vdo(((uint32_t) id.disc_id.cert_stat), 1, pd3p0_cert_stat_fields, pd3p0_cert_stat_field_desc);
+          printf("\t\tProduct\t\t:\t0x%08lx\n", id.disc_id.product);
+          print_vdo(((uint32_t) id.disc_id.product), 2, pd3p0_product_fields, pd3p0_product_field_desc);
+          break;
+        case 0x31:
+          printf("\t\tID Header\t:\t0x%08lx\n", id.disc_id.id_header);
+          get_vendor_string(vendor_id, sizeof(vendor_id), id_hdr_val.id_hdr_pd3p1.usb_vendor_id);
+          print_vdo(((uint32_t) id.disc_id.id_header), 8, pd3p1_cable_id_header_fields, pd3p1_cable_id_header_field_desc);
+          printf("\t\t\tDecoded VID\t:\t0x%04x (%s)\n", id_hdr_val.id_hdr_pd3p1.usb_vendor_id, (vendor_id == NULL ? "unknown" : vendor_id));
+          printf("\t\tCert Stat\t:\t0x%08lx\n", id.disc_id.cert_stat);
+          print_vdo(((uint32_t) id.disc_id.cert_stat), 1, pd3p1_cert_stat_fields, pd3p1_cert_stat_field_desc);
+          printf("\t\tProduct\t\t:\t0x%08lx\n", id.disc_id.product);
+          print_vdo(((uint32_t) id.disc_id.product), 2, pd3p1_product_fields, pd3p1_product_field_desc);
+          break;
+        default:
+          printf("\t\tID Header\t:\t0x%08lx\n", id.disc_id.id_header);
+          printf("\t\tCert Stat\t:\t0x%08lx\n", id.disc_id.cert_stat);
+          printf("\t\tProduct\t\t:\t0x%08lx\n", id.disc_id.product);
+          break;
+      }
+
+      //Product Type VDOs based on product type
+      enum product_type cable_product_type = get_cable_product_type(conn_data.cable_rev, ((uint32_t) id.disc_id.id_header));
+      switch (cable_product_type)
+      {
+        case product_type_pd2p0_passive_cable:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 15, pd2p0_passive_cable_fields, pd2p0_passive_cable_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+        case product_type_pd2p0_active_cable:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 15, pd2p0_active_cable_fields, pd2p0_active_cable_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+        case product_type_pd3p0_passive_cable:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 13, pd3p0_passive_cable_fields, pd3p0_passive_cable_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+        case product_type_pd3p0_active_cable:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 15, pd3p0_active_cable_vdo1_fields, pd3p0_active_cable_vdo1_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo2), 15, pd3p0_active_cable_vdo2_fields, pd3p0_active_cable_vdo2_field_desc);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+        case product_type_pd3p1_passive_cable:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 13, pd3p1_passive_cable_fields, pd3p1_passive_cable_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+        case product_type_pd3p1_active_cable:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 15, pd3p1_active_cable_vdo1_fields, pd3p1_active_cable_vdo1_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo2), 15, pd3p1_active_cable_vdo2_fields, pd3p1_active_cable_vdo2_field_desc);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+        case product_type_pd3p1_vpd:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          print_vdo(((uint32_t) id.disc_id.product_type_vdo1), 10, pd3p1_vpd_fields, pd3p0_vpd_field_desc);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+        default:
+          printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+          printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+          printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+          break;
+      }
+    }
+    else
+    {
+      printf("\t\tID Header\t:\t0x%08lx\n", id.disc_id.id_header);
+      printf("\t\tCert Stat\t:\t0x%08lx\n", id.disc_id.cert_stat);
+      printf("\t\tProduct\t\t:\t0x%08lx\n", id.disc_id.product);
+      printf("\t\tProduct VDO 1\t:\t0x%08lx\n", id.disc_id.product_type_vdo1);
+      printf("\t\tProduct VDO 2\t:\t0x%08lx\n", id.disc_id.product_type_vdo2);
+      printf("\t\tProduct VDO 3\t:\t0x%08lx\n", id.disc_id.product_type_vdo3);
+    }
+  }
 }
 
 void lstypec_print(char *val, int type)

--- a/utils/lstypec.h
+++ b/utils/lstypec.h
@@ -1,0 +1,861 @@
+/*
+    Copyright (c) 2021-2022 by Rajaram Regupathy, rajaram.regupathy@gmail.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; version 2 of the License.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+    details.
+
+    (See the full license text in the LICENSES directory)
+*/
+// SPDX-License-Identifier: GPL-2.0-only
+/**
+ * @file lstypec.c
+ * @author Rajaram Regupathy <rajaram.regupathy@gmail.com>
+ * @coauthor Jameson Thies <jthies@google.com>
+ * @brief Implements listing of typec port and port partner details
+ *
+ */
+
+#include <stdio.h>
+#include "../libtypec.h"
+#include "names.h"
+#include <stdlib.h>
+#include <stdint.h>
+
+#define LSTYPEC_MAJOR_VERSION 0
+#define LSTYPEC_MINOR_VERSION 1
+
+#define LSTYPEC_ERROR 1
+#define LSTYPEC_INFO 2
+
+#define MAX_FIELDS 16
+
+enum product_type {
+  product_type_other = 0,
+  product_type_pd2p0_passive_cable = 1,
+  product_type_pd2p0_active_cable = 2,
+  product_type_pd2p0_ama = 3,
+  product_type_pd3p0_passive_cable = 4,
+  product_type_pd3p0_active_cable = 5,
+  product_type_pd3p0_ama = 6,
+  product_type_pd3p0_vpd = 7,
+  product_type_pd3p0_ufp = 8,
+  product_type_pd3p0_dfp = 9,
+  product_type_pd3p0_drd = 10,
+  product_type_pd3p1_passive_cable = 11,
+  product_type_pd3p1_active_cable = 12,
+  product_type_pd3p1_vpd = 13,
+  product_type_pd3p1_ufp = 14,
+  product_type_pd3p1_dfp = 15,
+  product_type_pd3p1_drd = 16,
+};
+
+struct vdo_field{
+  char *name;
+  uint8_t print;
+  uint8_t index;
+  uint32_t mask;
+};
+
+union id_header
+{
+    uint32_t id_hdr;
+
+    struct
+    {
+        unsigned usb_vendor_id : 16;
+        unsigned reserved : 10;
+        unsigned modal_operation : 1;
+        unsigned product_type : 3;
+        unsigned usb_capable_device : 1;
+        unsigned usb_capable_host : 1;
+    } id_hdr_pd2p0;
+
+    struct
+    {
+        unsigned usb_vendor_id : 16;
+        unsigned reserved : 7;
+        unsigned prd_type_dfp : 3;
+        unsigned modal_operation : 1;
+        unsigned product_type : 3;
+        unsigned usb_capable_device : 1;
+        unsigned usb_capable_host : 1;
+    } id_hdr_pd3p0;
+
+    struct
+    {
+        unsigned usb_vendor_id : 16;
+        unsigned reserved : 5;
+        unsigned connector_type : 2;
+        unsigned prd_type_dfp : 3;
+        unsigned modal_operation : 1;
+        unsigned product_type : 3;
+        unsigned usb_capable_device : 1;
+        unsigned usb_capable_host : 1;
+    } id_hdr_pd3p1;
+};
+
+union passive_vdo_1
+{
+
+    uint32_t psv_vdo_1;
+
+    struct
+    {
+        unsigned usb_signalling : 3;
+        unsigned reserved3 : 1;
+        unsigned vbus_thru_cbl : 1;
+        unsigned vbus_handling : 2;
+        unsigned dir_support : 4;
+        unsigned termination_type : 2;
+        unsigned latency : 4;
+        unsigned reserved17 : 1;
+        unsigned plug_type : 2;
+        unsigned reserved20 : 4;
+        unsigned fw_ver : 4;
+        unsigned hw_ver : 4;
+    } psv_vdo1_pd2p0;
+
+    struct
+    {
+        unsigned usb_signalling : 3;
+        unsigned reserved3 : 2;
+        unsigned vbus_current_cap : 2;
+        unsigned reserved7 : 2;
+        unsigned vbus_max_volt : 2;
+        unsigned termination_type : 2;
+        unsigned latency : 4;
+        unsigned reserved17 : 1;
+        unsigned plug_type : 2;
+        unsigned reserved20 : 1;
+        unsigned vdo_version : 3;
+        unsigned fw_ver : 4;
+        unsigned hw_ver : 4;
+    } psv_vdo1_pd3p0;
+
+    struct
+    {
+        unsigned usb_signalling : 3;
+        unsigned reserved3 : 2;
+        unsigned vbus_current_cap : 2;
+        unsigned reserved7 : 2;
+        unsigned vbus_max_volt : 2;
+        unsigned termination_type : 2;
+        unsigned latency : 4;
+        unsigned epr_mode : 1;
+        unsigned plug_type : 2;
+        unsigned reserved20 : 1;
+        unsigned vdo_version : 3;
+        unsigned fw_ver : 4;
+        unsigned hw_ver : 4;
+    } psv_vdo1_pd3p1;
+};
+
+//Constants
+
+// ID Header product type masks
+const int pd_ufp_product_type_mask = 0x38000000;
+const int pd_dfp_product_type_mask = 0x03800000;
+
+const int pd2p0_passive_cable = 0x20000000;
+const int pd2p0_active_cable = 0x18000000;
+const int pd2p0_ama = 0x28000000;
+const int pd3p0_passive_cable = 0x18000000;
+const int pd3p0_active_cable = 0x20000000;
+const int pd3p0_ama = 0x28000000;
+const int pd3p0_vpd = 0x30000000;
+const int pd3p0_hub = 0x08000000;
+const int pd3p0_peripheral = 0x10000000;
+const int pd3p0_dfp_hub = 0x00800000;
+const int pd3p0_dfp_host = 0x01000000;
+const int pd3p0_power_brick = 0x01800000;
+const int pd3p1_passive_cable = 0x18000000;
+const int pd3p1_active_cable = 0x20000000;
+const int pd3p1_vpd = 0x30000000;
+const int pd3p1_hub = 0x08000000;
+const int pd3p1_peripheral = 0x10000000;
+const int pd3p1_dfp_hub = 0x00800000;
+const int pd3p1_dfp_host = 0x01000000;
+const int pd3p1_power_brick = 0x01800000;
+
+// USB PD 2.0 ID Header VDO (Section 6.4.4.3.1.1)
+const struct vdo_field pd2p0_partner_id_header_fields[] = {
+  {"USB Vendor ID", 1, 0, 0xffff},
+  {"Reserved", 0, 16, 0x3ff},
+  {"Modal Operation Supported", 1, 26, 0x1},
+  {"Produt Type (UFP)", 1, 27, 0x7},
+  {"USB Capable as a Device", 1, 30, 0x1},
+  {"USB Capable as a Host", 1, 31, 0x1},
+};
+const char *pd2p0_partner_id_header_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {"No", "Yes"},
+  {"Undefined", "PDUSB Hub", "PDUSB Peripheral", "Reserved", "Reserved", "Alternate Mode Adapter", "Reserved", "Reserved"},
+  {"No", "Yes"},
+  {"No", "Yes"},
+};
+const struct vdo_field pd2p0_cable_id_header_fields[] = {
+  {"USB Vendor ID", 1, 0, 0xffff},
+  {"Reserved", 0, 16, 0x3ff},
+  {"Modal Operation Supported", 1, 26, 0x1},
+  {"Produt Type (UFP)", 1, 27, 0x7},
+  {"USB Capable as a Device", 1, 30, 0x1},
+  {"USB Capable as a Host", 1, 31, 0x1},
+};
+const char *pd2p0_cable_id_header_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {"No", "Yes"},
+  {"Undefined", "Reserved", "Reserved", "Passive Cable", "Active Cable", "Reserved", "Reserved", "Reserved"},
+  {"No", "Yes"},
+  {"No", "Yes"},
+};
+
+// USB PD 2.0 Cert Stat VDO (Section 6.4.4.3.1.2)
+const struct vdo_field pd2p0_cert_stat_fields[] = {
+  {"XID", 1, 0, 0xffffffff},
+};
+const char *pd2p0_cert_stat_field_desc[][MAX_FIELDS] = {
+  {NULL},
+};
+
+// USB PD 2.0 Product VDO (Section 6.4.4.3.1.3)
+const struct vdo_field pd2p0_product_fields[] = {
+  {"bcdDevice", 1, 0, 0xffff},
+  {"USB Product ID", 1, 16, 0xffff},
+};
+const char *pd2p0_product_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+};
+
+// USB PD 2.0 Passive Cable VDO (Section 6.4.4.3.1.4.1)
+const struct vdo_field pd2p0_passive_cable_fields[] = {
+  {"USB SuperSpeed Support", 1, 0, 0x7},
+  {"Reserved", 0, 3, 0x1},
+  {"Vbus Through Cable", 1, 4, 0x1},
+  {"Vbus Current Handling", 1, 5, 0x3},
+  {"SSRX2 Support", 1, 7, 0x1},
+  {"SSRX1 Support", 1, 8, 0x1},
+  {"SSTX2 Support", 1, 9, 0x1},
+  {"SSTX1 Support", 1, 10, 0x1},
+  {"Cable Termination Type", 1, 11, 0x3},
+  {"Cable Latency", 1, 13, 0xf},
+  {"Reserved", 0, 17, 0x1},
+  {"USB Type-C plug to", 1, 18, 0x3},
+  {"Reserved", 0, 20, 0xf},
+  {"Firmware Version", 1, 24, 0xf},
+  {"HW Version", 1, 28, 0xf},
+};
+const char *pd2p0_passive_cable_field_desc[][MAX_FIELDS] = {
+  {"USB 2.0 Only", "USB 3.1 Gen1", "USB 3.1 Gen1 and Gen2", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {"No", "Yes"},
+  {"Reserved", "3A", "5A", "Reserved"},
+  {"Fixed", "Configurable"},
+  {"Fixed", "Configurable"},
+  {"Fixed", "Configurable"},
+  {"Fixed", "Configurable"},
+  {"Vconn Not Required", "Vconn Required", "Reserved", "Reserved"},
+  {"Reserved", "<10ns (~1m)", "10ns to 20ns (~2m)", "20ns to 30ns (~3m)", "30ns to 40ns (~4m)", "40ns to 50ns (~5m)", "50ns to 60ns (~6m)", "60ns to 70ns (~7m)", " 70ns (>~7m)", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {"USB Type-A", "USB Type-B", "USB Type-C", "Captive"},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 2.0 Active Cable VDO (Section 6.4.4.3.1.4.2)
+const struct vdo_field pd2p0_active_cable_fields[] = {
+  {"USB SuperSpeed Support", 1, 0, 0x7},
+  {"SOP'' Controller Present", 1, 3, 0x1},
+  {"Vbus Through Cable", 1, 4, 0x1},
+  {"Vbus Current Handling", 1, 5, 0x3},
+  {"SSRX2 Support", 1, 7, 0x1},
+  {"SSRX1 Support", 1, 8, 0x1},
+  {"SSTX2 Support", 1, 9, 0x1},
+  {"SSTX1 Support", 1, 10, 0x1},
+  {"Cable Termination Type", 1, 11, 0x3},
+  {"Cable Latency", 1, 13, 0xf},
+  {"Reserved", 0, 17, 0x1},
+  {"USB Type-C plug to", 1, 18, 0x3},
+  {"Reserved", 0, 20, 0xf},
+  {"Firmware Version", 1, 24, 0xf},
+  {"HW Version", 1, 28, 0xf},
+};
+const char *pd2p0_active_cable_field_desc[][MAX_FIELDS] = {
+  {"USB 2.0 Only", "USB 3.1 Gen1", "USB 3.1 Gen1 and Gen2", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {"No", "Yes"},
+  {"Reserved", "3A", "5A", "Reserved"},
+  {"Fixed", "Configurable"},
+  {"Fixed", "Configurable"},
+  {"Fixed", "Configurable"},
+  {"Fixed", "Configurable"},
+  {"Vconn Not Required", "Vconn Required", "Reserved", "Reserved"},
+  {"Reserved", "<10ns (~1m)", "10ns to 20ns (~2m)", "20ns to 30ns (~3m)", "30ns to 40ns (~4m)", "40ns to 50ns (~5m)", "50ns to 60ns (~6m)", "60ns to 70ns (~7m)", " 70ns (>~7m)", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {"USB Type-A", "USB Type-B", "USB Type-C", "Captive"},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 2.0 AMA VDO (Section 6.4.4.3.1.5)
+const struct vdo_field pd2p0_ama_fields[] = {
+  {"USB SuperSpeed Support", 1, 0, 0x7},
+  {"Vbus required", 1, 3, 0x1},
+  {"Vconn required", 1, 4, 0x1},
+  {"Vconn power", 1, 5, 0x7},
+  {"SSRX2 Support", 1, 8, 0x1},
+  {"SSRX1 Support", 1, 9, 0x1},
+  {"SSTX2 Support", 1, 10, 0x1},
+  {"SSTX1 Support", 1, 11, 0x1},
+  {"Reserved", 0, 12, 0xfff},
+  {"Firmware Version", 1, 24, 0xf},
+  {"HW Version", 1, 28, 0xf},
+};
+const char *pd2p0_ama_field_desc[][MAX_FIELDS] = {
+  {"USB 2.0 Only", "USB 3.1 Gen1", "USB 3.1 Gen1 and Gen2", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {"No", "Yes"},
+  {"No", "Yes"},
+  {"1W", "1.5W", "2W", "3W", "4W", "5W", "6W", "Reserved"},
+  {"Fixed", "Configurable"},
+  {"Fixed", "Configurable"},
+  {"Fixed", "Configurable"},
+  {"Fixed", "Configurable"},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+
+// USB PD 3.0 ID Header VDO (Section 6.4.4.3.1.1)
+const struct vdo_field pd3p0_partner_id_header_fields[] = {
+  {"USB Vendor ID", 1, 0, 0xffff},
+  {"Reserved", 0, 16, 0x3f},
+  {"Product Type (DFP)", 1, 23, 0x7},
+  {"Modal Operation Supported", 1, 26, 0x1},
+  {"Product Type (UFP)", 1, 27, 0x7},
+  {"USB Capable as a Device", 1, 30, 0x1},
+  {"USB Capable as a Host", 1, 31, 0x1},
+};
+const char *pd3p0_partner_id_header_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {"Undefined", "PDUSB Hub", "PDUSB Host", "Power Brick", "Alternate Mode Controller", "Reserved", "Reserved", "Reserved"},
+  {"No", "Yes"},
+  {"Undefined", "PDUSB Hub", "PDUSB Peripheral", "PSD", "Reserved", "Alternate Mode Adapter", "Vconn Powered USB Device", "Reserved"},
+  {"No", "Yes"},
+  {"No", "Yes"},
+};
+const struct vdo_field pd3p0_cable_id_header_fields[] = {
+  {"USB Vendor ID", 1, 0, 0xffff},
+  {"Reserved", 0, 16, 0x3f},
+  {"Product Type (DFP)", 0, 23, 0x7},
+  {"Modal Operation Supported", 1, 26, 0x1},
+  {"Product Type (Cable Plug)", 1, 27, 0x7},
+  {"USB Capable as a Device", 1, 30, 0x1},
+  {"USB Capable as a Host", 1, 31, 0x1},
+};
+const char *pd3p0_cable_id_header_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {"No", "Yes"},
+  {"Undefined", "Reserved", "Reserved", "Passive Cable", "Active Cable", "Reserved", "Reserved", "Reserved"},
+  {"No", "Yes"},
+  {"No", "Yes"},
+};
+
+// USB PD 3.0 Cert Stat VDO (Section 6.4.4.3.1.2)
+const struct vdo_field pd3p0_cert_stat_fields[] = {
+  {"XID", 1, 0, 0xffffffff},
+};
+const char *pd3p0_cert_stat_field_desc[][MAX_FIELDS] = {
+  {NULL},
+};
+
+// USB PD 3.0 Product VDO (Section 6.4.4.3.1.3)
+const struct vdo_field pd3p0_product_fields[] = {
+  {"bcdDevice", 1, 0, 0xffff},
+  {"USB Product ID", 1, 16, 0xffff},
+};
+const char *pd3p0_product_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.0 Passive Cable VDO (Section 6.4.4.3.1.6)
+const struct vdo_field pd3p0_passive_cable_fields[] = {
+  {"USB Highest Speed", 1, 0, 0x7},
+  {"Reserved", 0, 3, 0x3},
+  {"Vbus Current Handling", 1, 5, 0x3},
+  {"Reserved", 0, 7, 0x3},
+  {"Maximum Vbus Voltage", 1, 9, 0x3},
+  {"Cable Termination Type", 1, 11, 0x3},
+  {"Cable Latency", 1, 13, 0xf},
+  {"Reserved", 0, 17, 0x1},
+  {"Connector Type", 1, 18, 0x3},
+  {"Reserved", 0, 20, 0x1},
+  {"VDO version", 1, 21, 0x7},
+  {"Firmware Version", 1, 24, 0xf},
+  {"HW Version", 1, 28, 0xf},
+};
+const char *pd3p0_passive_cable_field_desc[][MAX_FIELDS] = {
+  {"USB 2.0 Only", "USB 3.2 Gen1", "USB 3.2/USB4 Gen2", "USB4 Gen3", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {"Reserved", "3A", "5A", "Reserved"},
+  {NULL},
+  {"20V", "30V", "40V", "50V"},
+  {"Vconn Not Required", "Vconn Required", "Reserved", "Reserved"},
+  {"Reserved", "<10ns (~1m)", "10ns to 20ns (~2m)", "20ns to 30ns (~3m)", "30ns to 40ns (~4m)", "40ns to 50ns (~5m)", "50ns to 60ns (~6m)", "60ns to 70ns (~7m)", " 70ns (>~7m)", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {"Reserved", "Reserved", "USB Type-C", "Captive"},
+  {NULL},
+  {"Version 1.0", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.0 Active Cable VDO1/VDO2 (Section 6.4.4.3.1.7)
+const struct vdo_field pd3p0_active_cable_vdo1_fields[] = {
+  {"USB Highest Speed", 1, 0, 0x7},
+  {"SOP'' Controller Present", 1, 3, 0x1},
+  {"Vbus Through Cable", 1, 4, 0x1},
+  {"Vbus Current Handling", 1, 5, 0x3},
+  {"SBU Type", 1, 7, 0x1},
+  {"SBU Supported", 1, 8, 0x1},
+  {"Maximum Vbus Voltage", 1, 9, 0x3},
+  {"Cable Termination Type", 1, 11, 0x3},
+  {"Cable Latency", 1, 13, 0xf},
+  {"Reserved", 0, 17, 0x1},
+  {"Conector Type", 1, 18, 0x3},
+  {"Reserved", 0, 20, 0x1},
+  {"VDO version", 1, 21, 0x7},
+  {"Firmware Version", 1, 24, 0xf},
+  {"HW Version", 1, 28, 0xf},
+};
+const char *pd3p0_active_cable_vdo1_field_desc[][MAX_FIELDS] = {
+  {"USB 2.0 Only", "USB 3.2 Gen1", "USB 3.2/USB4 Gen2", "USB4 Gen3", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {"No", "Yes"},
+  {"No", "Yes"},
+  {"USB Type-C Default Current", "3A", "5A", "Reserved"},
+  {"SBU is passive", "SBU is active"},
+  {"SBU connections supported", "SBU connections are not supported"},
+  {"20V", "30V", "40V", "50V"},
+  {"Reserved", "Reserved", "One end active, one end passive, Vconn required", "Both ends active, Vconn required"},
+  {"Reserved", "<10ns (~1m)", "10ns to 20ns (~2m)", "20ns to 30ns (~3m)", "30ns to 40ns (~4m)", "40ns to 50ns (~5m)", "50ns to 60ns (~6m)", "60ns to 70ns (~7m)", "1000b –1000ns (~100m)", "1001b –2000ns (~200m)", "1010b – 3000ns (~300m)", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {"Reserved", "Reserved", "USB Type-C", "Captive"},
+  {NULL},
+  {"Reserved", "Reserved", "Reserved", "Version 1.3", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {NULL},
+};
+const struct vdo_field pd3p0_active_cable_vdo2_fields[] = {
+  {"USB Gen", 1, 0, 0x1},
+  {"Reserved", 0, 1, 0x1},
+  {"Optically Isolated Active Cable", 1, 2, 0x1},
+  {"USB Lanes Supported", 1, 3, 0x1},
+  {"USB 3.2 Supported", 1, 4, 0x1},
+  {"USB 2.0 Supported", 1, 5, 0x1},
+  {"USB 2.0 Hub Hops Consumed", 1, 6, 0x3},
+  {"USB4 Supported", 1, 8, 0x1},
+  {"Active element", 1, 9, 0x1},
+  {"Physical connection", 1, 10, 0x1},
+  {"U3 to U0 transition mode", 1, 11, 0x1},
+  {"U3/Cld Power", 1, 12, 0x7},
+  {"Reserved", 0, 15, 0x1},
+  {"Shutdown Tempurature", 1, 16, 0xff},
+  {"Maximum Operating Tempurature", 1, 24, 0xff},
+};
+const char *pd3p0_active_cable_vdo2_field_desc[][MAX_FIELDS] = {
+  {"Gen 1", "Gen 2 or higher"},
+  {NULL},
+  {"No", "Yes"},
+  {"One Lane", "Two Lanes"},
+  {"USB 3.2 SuperSpeed supported", "USB 3.2 SuperSpeed not supported"},
+  {"USB 2.0 supported", "USB 2.0 not supported"},
+  {NULL},
+  {"USB4 Supported", "USB4 Not Supported"},
+  {"Active Redriver", "Active Retimer"},
+  {"Copper", "Optical"},
+  {"U3 to U0 direct", "U3 to U0 through U35"},
+  {">10mW", "5-10mW", "1-5mW", "0.5-1mW", "0.2-0.5mW", "50-200uW", "<50uW", "Reserved"},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.0 AMA VDO (Section 6.4.4.3.1.8)
+const struct vdo_field pd3p0_ama_fields[] = {
+  {"USB Highest Speed", 1, 0, 0x7},
+  {"Vbus required", 1, 3, 0x1},
+  {"Vconn required", 1, 4, 0x1},
+  {"Vconn power", 1, 5, 0x7},
+  {"Reserved", 0, 8, 0x1fff},
+  {"VDO Version", 1, 21, 0x7},
+  {"Firmware Version", 1, 24, 0xf},
+  {"HW Version", 1, 28, 0xf},
+};
+const char *pd3p0_ama_field_desc[][MAX_FIELDS] = {
+  {"USB 2.0 only", "USB 3.2 Gen1 and USB 2.0", "USB 3.2 Gen1, Gen2 and USB 2.0", "billboard only", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {"No", "Yes"},
+  {"No", "Yes"},
+  {"1W", "1.5W", "2W", "3W", "4W", "5W", "6W", "Reserved"},
+  {NULL},
+  {"Version 1.0", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.0 VPD VDO (Section 6.4.4.3.1.9)
+const struct vdo_field pd3p0_vpd_fields[] = {
+  {"Charge Through Support", 1, 0, 0x1},
+  {"Ground Impedance", 1, 1, 0x3f},
+  {"Vbus Impedance", 1, 7, 0x3f},
+  {"Reserved", 0, 13, 0x3},
+  {"Charge Through Current Support", 1, 14, 0x1},
+  {"Maximum Vbus Voltage", 1, 15, 0x3},
+  {"Reserved", 0, 17, 0xf},
+  {"VDO Version", 1, 21, 0x7},
+  {"Firmware Version", 1, 24, 0xf},
+  {"HW Version", 1, 28, 0xf},
+};
+const char *pd3p0_vpd_field_desc[][MAX_FIELDS] = {
+  {"No","Yes"},
+  {NULL},
+  {NULL},
+  {NULL},
+  {"3A capable", "5A capable"},
+  {"20V", "30V", "40V", "50V"},
+  {NULL},
+  {"Version 1.0", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.0 UFP VDO1/VDO2 (Section 6.4.4.3.1.4)
+const struct vdo_field pd3p0_ufp_vdo1_fields[] = {
+  {"USB Highest Speed", 1, 0, 0x7},
+  {"Alternate Modes", 1, 3, 0x7},
+  {"Reserved", 0, 6, 0x3ffff},
+  {"Device Capability", 1, 24, 0xf},
+  {"Reserved", 0, 28, 0x1},
+  {"UFP VDO Version", 1, 29, 0x7},
+};
+const char *pd3p0_ufp_vdo1_field_desc[][MAX_FIELDS] = {
+  {"USB 2.0 only", "USB 3.2 Gen1", "USB 3.2/USB4 Gen2", "USB4 Gen3", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {"Version 1.0", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+};
+const struct vdo_field pd3p0_ufp_vdo2_fields[] = {
+  {"USB3 Max Power", 1, 0, 0x7f},
+  {"USB3 Min Power", 1, 7, 0x7f},
+  {"Reserved", 0, 14, 0x3},
+  {"USB4 Max Power", 1, 16, 0x7f},
+  {"USB4 Min Power", 1, 23, 0x7f},
+  {"Reserved", 0, 30, 0x3},
+};
+const char *pd3p0_ufp_vdo2_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.0 DFP VDO (Section 6.4.4.3.1.5)
+const struct vdo_field pd3p0_dfp_fields[] = {
+  {"Port Number", 1, 0, 0x1f},
+  {"Reserved", 0, 5, 0x7ffff},
+  {"Host Capability", 1, 24, 0x7},
+  {"Reserved", 0, 27, 0x3},
+  {"DFP VDO Version", 1, 29, 0x7},
+};
+const char *pd3p0_dfp_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {"Version 1.0", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+};
+
+
+// USB PD 3.1 ID Header VDO (Section 6.4.4.3.1.1)
+const struct vdo_field pd3p1_partner_id_header_fields[] = {
+  {"USB Vendor ID", 1, 0, 0xffff},
+  {"Reserved", 0, 16, 0x1f},
+  {"Connector Type", 1, 21, 0x3},
+  {"Product Type (DFP)", 1, 23, 0x7},
+  {"Modal Operation Supported", 1, 26, 0x1},
+  {"Product Type (UFP)", 1, 27, 0x7},
+  {"USB Capable as a Device", 1, 30, 0x1},
+  {"USB Capable as a Host", 1, 31, 0x1},
+};
+const char *pd3p1_partner_id_header_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {"Reserved", "Reserved", "USB Type-C Receptacle", "USB Type-C Plug"},
+  {"Undefined", "PDUSB Hub", "PDUSB Host", "Power Brick", "Alternate Mode Controller", "Reserved", "Reserved", "Reserved"},
+  {"No", "Yes"},
+  {"Undefined", "PDUSB Hub", "PDUSB Peripheral", "PSD", "Reserved", "Alternate Mode Adapter", "Vconn Powered USB Device", "Reserved"},
+  {"No", "Yes"},
+  {"No", "Yes"},
+};
+const struct vdo_field pd3p1_cable_id_header_fields[] = {
+  {"USB Vendor ID", 1, 0, 0xffff},
+  {"Reserved", 0, 16, 0x1f},
+  {"Connector Type", 1, 21, 0x3},
+  {"Product Type (DFP)", 0, 23, 0x7},
+  {"Modal Operation Supported", 1, 26, 0x1},
+  {"Product Type (Cable Plug)", 1, 27, 0x7},
+  {"USB Capable as a Device", 1, 30, 0x1},
+  {"USB Capable as a Host", 1, 31, 0x1},
+};
+const char *pd3p1_cable_id_header_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {"Reserved", "Reserved", "USB Type-C Receptacle", "USB Type-C Plug"},
+  {NULL},
+  {"No", "Yes"},
+  {"Undefined", "Reserved", "Reserved", "Passive Cable", "Active Cable", "Reserved", "Reserved", "Reserved"},
+  {"No", "Yes"},
+  {"No", "Yes"},
+};
+
+// USB PD 3.1 Cert Stat VDO (Section 6.4.4.3.1.2)
+const struct vdo_field pd3p1_cert_stat_fields[] = {
+  {"XID", 1, 0, 0xffffffff},
+};
+const char *pd3p1_cert_stat_field_desc[][MAX_FIELDS] = {
+  {NULL},
+};
+
+// USB PD 3.1 Product VDO (Section 6.4.4.3.1.3)
+const struct vdo_field pd3p1_product_fields[] = {
+  {"bcdDevice", 1, 0, 0xffff},
+  {"USB Product ID", 1, 16, 0xffff},
+};
+const char *pd3p1_product_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.1 Passive Cable VDO (Section 6.4.4.3.1.6)
+const struct vdo_field pd3p1_passive_cable_fields[] = {
+  {"USB Highest Speed", 1, 0, 0x7},
+  {"Reserved", 0, 3, 0x3},
+  {"Vbus Current Handling", 1, 5, 0x3},
+  {"Reserved", 0, 7, 0x3},
+  {"Maximum Vbus Voltage", 1, 9, 0x3},
+  {"Cable Termination Type", 1, 11, 0x3},
+  {"Cable Latency", 1, 13, 0xf},
+  {"EPR Mode Capable", 1, 17, 0x1},
+  {"Type-C Connector to", 1, 18, 0x3},
+  {"Reserved", 0, 20, 0x1},
+  {"VDO version", 1, 21, 0x7},
+  {"Firmware Version", 1, 24, 0xf},
+  {"HW Version", 1, 28, 0xf},
+};
+const char *pd3p1_passive_cable_field_desc[][MAX_FIELDS] = {
+  {"USB 2.0 Only", "USB 3.2 Gen1", "USB 3.2/USB4 Gen2", "USB4 Gen3", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {"Reserved", "3A", "5A", "Reserved"},
+  {NULL},
+  {"20V", "30V (Deprecated)", "40V (Deprecated)", "50V"},
+  {"Vconn Not Required", "Vconn Required", "Reserved", "Reserved"},
+  {"Reserved", "<10ns (~1m)", "10ns to 20ns (~2m)", "20ns to 30ns (~3m)", "30ns to 40ns (~4m)", "40ns to 50ns (~5m)", "50ns to 60ns (~6m)", "60ns to 70ns (~7m)", " 70ns (>~7m)", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {"No", "Yes"},
+  {"Reserved", "Reserved", "USB Type-C", "Captive"},
+  {NULL},
+  {"Version 1.0", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.1 Active Cable VDO1/VDO2 (Section 6.4.4.3.1.7)
+const struct vdo_field pd3p1_active_cable_vdo1_fields[] = {
+  {"USB Highest Speed", 1, 0, 0x7},
+  {"SOP'' Controller Present", 1, 3, 0x1},
+  {"Vbus Through Cable", 1, 4, 0x1},
+  {"Vbus Current Handling", 1, 5, 0x3},
+  {"SBU Type", 1, 7, 0x1},
+  {"SBU Supported", 1, 8, 0x1},
+  {"Maximum Vbus Voltage", 1, 9, 0x3},
+  {"Cable Termination Type", 1, 11, 0x3},
+  {"Cable Latency", 1, 13, 0xf},
+  {"EPR Mode Capable", 1, 17, 0x1},
+  {"USB Type-C to", 1, 18, 0x3},
+  {"Reserved", 0, 20, 0x1},
+  {"VDO version", 1, 21, 0x7},
+  {"Firmware Version", 1, 24, 0xf},
+  {"HW Version", 1, 28, 0xf},
+};
+const char *pd3p1_active_cable_vdo1_field_desc[][MAX_FIELDS] = {
+  {"USB 2.0 Only", "USB 3.2 Gen1", "USB 3.2/USB4 Gen2", "USB4 Gen3", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {"No", "Yes"},
+  {"No", "Yes"},
+  {"USB Type-C Default Current", "3A", "5A", "Reserved"},
+  {"SBU is passive", "SBU is active"},
+  {"SBU connections supported", "SBU connections are not supported"},
+  {"20V", "30V", "40V", "50V"},
+  {"Reserved", "Reserved", "One end active, one end passive, Vconn required", "Both ends active, Vconn required"},
+  {"Reserved", "<10ns (~1m)", "10ns to 20ns (~2m)", "20ns to 30ns (~3m)", "30ns to 40ns (~4m)", "40ns to 50ns (~5m)", "50ns to 60ns (~6m)", "60ns to 70ns (~7m)", "1000b –1000ns (~100m)", "1001b –2000ns (~200m)", "1010b – 3000ns (~300m)", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {"No", "Yes"},
+  {"Reserved", "Reserved", "USB Type-C", "Captive"},
+  {NULL},
+  {"Reserved", "Reserved", "Reserved", "Version 1.3", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {NULL},
+};
+const struct vdo_field pd3p1_active_cable_vdo2_fields[] = {
+  {"USB Gen", 1, 0, 0x1},
+  {"Reserved", 0, 1, 0x1},
+  {"Optically Isolated Active Cable", 1, 2, 0x1},
+  {"USB Lanes Supported", 1, 3, 0x1},
+  {"USB 3.2 Supported", 1, 4, 0x1},
+  {"USB 2.0 Supported", 1, 5, 0x1},
+  {"USB 2.0 Hub Hops Consumed", 1, 6, 0x3},
+  {"USB4 Supported", 1, 8, 0x1},
+  {"Active element", 1, 9, 0x1},
+  {"Physical connection", 1, 10, 0x1},
+  {"U3 to U0 transition mode", 1, 11, 0x1},
+  {"U3/Cld Power", 1, 12, 0x7},
+  {"Reserved", 0, 15, 0x1},
+  {"Shutdown Tempurature", 1, 16, 0xff},
+  {"Maximum Operating Tempurature", 1, 24, 0xff},
+};
+const char *pd3p1_active_cable_vdo2_field_desc[][MAX_FIELDS] = {
+  {"Gen 1", "Gen 2 or higher"},
+  {NULL},
+  {"No", "Yes"},
+  {"One Lane", "Two Lanes"},
+  {"USB 3.2 SuperSpeed supported", "USB 3.2 SuperSpeed not supported"},
+  {"USB 2.0 supported", "USB 2.0 not supported"},
+  {NULL},
+  {"USB4 Supported", "USB4 Not Supported"},
+  {"Active Redriver", "Active Retimer"},
+  {"Copper", "Optical"},
+  {"U3 to U0 direct", "U3 to U0 through U35"},
+  {">10mW", "5-10mW", "1-5mW", "0.5-1mW", "0.2-0.5mW", "50-200uW", "<50uW", "Reserved"},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.0 VPD VDO (Section 6.4.4.3.1.9)
+const struct vdo_field pd3p1_vpd_fields[] = {
+  {"Charge Through Support", 1, 0, 0x1},
+  {"Ground Impedance", 1, 1, 0x3f},
+  {"Vbus Impedance", 1, 7, 0x3f},
+  {"Reserved", 0, 13, 0x3},
+  {"Charge Through Current Support", 1, 14, 0x1},
+  {"Maximum Vbus Voltage", 1, 15, 0x3},
+  {"Reserved", 0, 17, 0xf},
+  {"VDO Version", 1, 21, 0x7},
+  {"Firmware Version", 1, 24, 0xf},
+  {"HW Version", 1, 28, 0xf},
+};
+const char *pd3p1_vpd_field_desc[][MAX_FIELDS] = {
+  {"No","Yes"},
+  {NULL},
+  {NULL},
+  {NULL},
+  {"3A capable", "5A capable"},
+  {"20V", "30V (Deprecated)", "40V (Deprecated)", "50V (Deprecated)"},
+  {NULL},
+  {"Version 1.0", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.1 UFP VDO (Section 6.4.4.3.1.4)
+const struct vdo_field pd3p1_ufp_fields[] = {
+  {"USB Highest Speed", 1, 0, 0x7},
+  {"Alternate Modes", 1, 3, 0x7},
+  {"Vbus Required", 1, 6, 0x1},
+  {"Vconn Required", 1, 7, 0x1},
+  {"Vconn Power", 1, 8, 0x7},
+  {"Reserved", 0, 11, 0x7ff},
+  {"Connector Type", 1, 22, 0x3},
+  {"Device Capability", 1, 24, 0xf},
+  {"Reserved", 0, 28, 0x1},
+  {"UFP VDO Version", 1, 29, 0x7},
+};
+const char *pd3p1_ufp_field_desc[][MAX_FIELDS] = {
+  {"USB 2.0 only", "USB 3.2 Gen1", "USB 3.2/USB4 Gen2", "USB4 Gen3", "Reserved", "Reserved", "Reserved", "Reserved"},
+  {NULL},
+  {"Yes", "No"},
+  {"No", "Yes"},
+  {"1W", "1.5W", "2W", "3W", "4W", "5W", "6W", "Reserved"},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {"Reserved", "Reserved", "Reserved", "Version 1.3", "Reserved", "Reserved", "Reserved", "Reserved"},
+};
+
+// USB PD 3.1 DFP VDO (Section 6.4.4.3.1.5)
+const struct vdo_field pd3p1_dfp_fields[] = {
+  {"Port Number", 1, 0, 0x1f},
+  {"Reserved", 0, 5, 0x1ffff},
+  {"Connector Type", 1, 22, 0x3},
+  {"Host Capability", 1, 24, 0x7},
+  {"Reserved", 0, 27, 0x3},
+  {"DFP VDO Version", 1, 29, 0x7},
+};
+const char *pd3p1_dfp_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {"Version 1.0", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
+};
+
+
+struct libtypec_capabiliy_data get_cap_data;
+struct libtypec_connector_cap_data conn_data;
+struct libtypec_connector_status conn_sts;
+struct libtypec_cable_property cable_prop;
+union libtypec_discovered_identity id;
+
+struct altmode_data am_data[64];
+char *session_info[LIBTYPEC_SESSION_MAX_INDEX];
+
+// TODO: Add comments describing each function
+// Used to determine a cable plug's product type
+enum product_type get_cable_product_type(short rev, uint32_t id);
+
+// Used to determine a partner's product type
+enum product_type get_partner_product_type(short rev, uint32_t id);
+
+//print_vdo will expand and print a VDO
+void print_vdo(uint32_t vdo, int num_fields, struct vdo_field vdo_fields[], char *vdo_field_desc[][MAX_FIELDS]);
+
+void print_session_info();
+
+void print_ppm_capability(struct libtypec_capabiliy_data ppm_data);
+
+void print_conn_capability(struct libtypec_connector_cap_data conn_data);
+
+void print_cable_prop(struct libtypec_cable_property cable_prop, int conn_num);
+
+void print_alternate_mode_data(int recipient, int num_mode, struct altmode_data *am_data);
+
+void print_identity_data(int recipient, union libtypec_discovered_identity id);
+
+void lstypec_print(char *val, int type);
+


### PR DESCRIPTION
This commit adds to the existing VDO decoding in lstypec to include
active cables, AMAs, VPDs, DFPs, UFPs and DRDs from USB PD Revisions
2.0, 3.0 and 3.1 where applicable. It also moves data structure
definitions, constant definitions and function prototypes from lstypec
into a header file.