### PR TITLE
Fix various spelling mistakes found using the codespell tool

### DIFF
--- a/libtypec.c
+++ b/libtypec.c
@@ -168,7 +168,7 @@ int libtypec_exit(void)
 /**
  * This function shall be used to get the platform policy capabilities
  *
- * \param  cap_data Data structure to hold platform capabilty
+ * \param  cap_data Data structure to hold platform capability
  *
  * \returns 0 on success
  */
@@ -183,9 +183,9 @@ int libtypec_get_capability(struct libtypec_capabiliy_data *cap_data)
 /**
  * This function shall be used to get the capabilities of a connector
  *
- * \param  conn_num Indicates which connector's capability needs to be retrived
+ * \param  conn_num Indicates which connector's capability needs to be retrieved
  *
- * \param  conn_cap_data Data structure to hold connector capabilty
+ * \param  conn_cap_data Data structure to hold connector capability
  *
  * \returns 0 on success
  */
@@ -204,7 +204,7 @@ int libtypec_get_conn_capability(int conn_num, struct libtypec_connector_cap_dat
  * \param  recipient Represents alternate mode to be retrieved from local
  * or SOP or SOP' or SOP"
  *
- * \param  conn_num Indicates which connector's capability needs to be retrived
+ * \param  conn_num Indicates which connector's capability needs to be retrivied
  *
  * \returns number of alternate modes on success
  */
@@ -218,7 +218,7 @@ int libtypec_get_alternate_modes(int recipient, int conn_num, struct altmode_dat
 /**
  * This function shall be used to get the Cable Property of a connector
  *
- * \param  conn_num Indicates which connector's status needs to be retrived
+ * \param  conn_num Indicates which connector's status needs to be retrieved
  *
  * \returns 0 on success
  */
@@ -233,7 +233,7 @@ int libtypec_get_cable_properties(int conn_num, struct libtypec_cable_property *
 /**
  * This function shall be used to get the Connector status
  *
- * \param  conn_num Indicates which connector's status needs to be retrived
+ * \param  conn_num Indicates which connector's status needs to be retrieved
  *
  * \returns 0 on success
  */
@@ -251,7 +251,7 @@ int libtypec_get_connector_status(int conn_num, struct libtypec_connector_status
  * \param  recipient Represents PD response message to be retrieved from local
  * or SOP or SOP' or SOP"
  *
- * \param  conn_num Indicates which connector's PD message needs to be retrived
+ * \param  conn_num Indicates which connector's PD message needs to be retrieved
  *
  * \param pd_msg_resp
  * \returns 0 on success

--- a/libtypec.h
+++ b/libtypec.h
@@ -40,10 +40,10 @@ struct libtypec_capabiliy_data
 {
     unsigned int bmAttributes;
     unsigned bNumConnectors : 7;
-    unsigned reserved : 1;
+    unsigned reserved1 : 1;
     unsigned bmOptionalFeatures : 24;
     unsigned bNumAltModes : 8;
-    unsigned reserverd : 8;
+    unsigned reserved2 : 8;
     unsigned bcdBCVersion : 16;
     unsigned bcdPDVersion : 16;
     unsigned bcdTypeCVersion : 16;

--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -636,7 +636,7 @@ static int libtypec_sysfs_get_cable_properties_ops(int conn_num, struct libtypec
 
 	sprintf(path_str, SYSFS_TYPEC_PATH "/port%d-cable", conn_num);
 
-	/* No cable indentified or connector number is incorrect */
+	/* No cable identified or connector number is incorrect */
 	if (lstat(path_str, &sb) == -1)
 		return -1;
 

--- a/utils/lstypec.c
+++ b/utils/lstypec.c
@@ -573,7 +573,7 @@ int main(int argc, char *argv[])
     cable_prop.plug_end_type = PLUG_TYPE_OTH;
 
     // Connector Capabilities
-    printf("\nConnector %d Capablity/Status\n", i);
+    printf("\nConnector %d Capability/Status\n", i);
     libtypec_get_conn_capability(i, &conn_data);
     print_conn_capability(conn_data);
 

--- a/utils/lstypec.h
+++ b/utils/lstypec.h
@@ -445,7 +445,7 @@ const struct vdo_field pd3p0_active_cable_vdo1_fields[] = {
   {"Cable Termination Type", 1, 11, 0x3},
   {"Cable Latency", 1, 13, 0xf},
   {"Reserved", 0, 17, 0x1},
-  {"Conector Type", 1, 18, 0x3},
+  {"Connector Type", 1, 18, 0x3},
   {"Reserved", 0, 20, 0x1},
   {"VDO version", 1, 21, 0x7},
   {"Firmware Version", 1, 24, 0xf},
@@ -482,8 +482,8 @@ const struct vdo_field pd3p0_active_cable_vdo2_fields[] = {
   {"U3 to U0 transition mode", 1, 11, 0x1},
   {"U3/Cld Power", 1, 12, 0x7},
   {"Reserved", 0, 15, 0x1},
-  {"Shutdown Tempurature", 1, 16, 0xff},
-  {"Maximum Operating Tempurature", 1, 24, 0xff},
+  {"Shutdown Temperature", 1, 16, 0xff},
+  {"Maximum Operating Temperature", 1, 24, 0xff},
 };
 const char *pd3p0_active_cable_vdo2_field_desc[][MAX_FIELDS] = {
   {"Gen 1", "Gen 2 or higher"},
@@ -743,8 +743,8 @@ const struct vdo_field pd3p1_active_cable_vdo2_fields[] = {
   {"U3 to U0 transition mode", 1, 11, 0x1},
   {"U3/Cld Power", 1, 12, 0x7},
   {"Reserved", 0, 15, 0x1},
-  {"Shutdown Tempurature", 1, 16, 0xff},
-  {"Maximum Operating Tempurature", 1, 24, 0xff},
+  {"Shutdown Temperature", 1, 16, 0xff},
+  {"Maximum Operating Temperature", 1, 24, 0xff},
 };
 const char *pd3p1_active_cable_vdo2_field_desc[][MAX_FIELDS] = {
   {"Gen 1", "Gen 2 or higher"},
@@ -840,7 +840,7 @@ const struct vdo_field dp_alt_mode_partner_fields[] = {
   {"Signaling for Transport of DisplaPort Protocol", 1, 2, 0xf},
   {"Receptacle Indication", 1, 6, 0x1},
   {"USB 2.0 Signaling Not Used", 1, 7, 0x1},
-  {"DP Source Device Pin Suported", 1, 8, 0xff},
+  {"DP Source Device Pin Supported", 1, 8, 0xff},
   {"DP Sink Device Pin Supported", 1, 16, 0xff},
   {"Reserved", 0, 24, 0xff},
 };


### PR DESCRIPTION
Fix various spelling mistakes in comments and literal strings and struct field members.

Signed-off-by: Colin Ian King <colin.i.king@gmail.com>