### PR TITLE
libtypec: Add PDO support to lstypec

### DIFF
--- a/libtypec.h
+++ b/libtypec.h
@@ -119,18 +119,18 @@ union libtypec_fixed_supply_src
     unsigned fixed_supply;
     struct fixed_supply_bits
     {
-        unsigned type:2;
-        unsigned dual_pwr:1;
-        unsigned usb_suspend:1;
-        unsigned uncons_pwr:1;
-        unsigned usb_comm:1;
-        unsigned drd:1;
-        unsigned unchunked:1;
-        unsigned epr:1;
-        unsigned rsvd:1;
-        unsigned peak_cur:2;
-        unsigned volt:10;
         unsigned max_cur:10;
+        unsigned volt:10;
+        unsigned peak_cur:2;
+        unsigned rsvd:1;
+        unsigned epr:1;
+        unsigned unchunked:1;
+        unsigned drd:1;
+        unsigned usb_comm:1;
+        unsigned uncons_pwr:1;
+        unsigned usb_suspend:1;
+        unsigned dual_pwr:1;
+        unsigned type:2;
     }obj_fixed_sply;
     
 };
@@ -140,10 +140,10 @@ union libtypec_variable_supply_src
     unsigned int variable_supply;
     struct variable_supply_bits
     {
-        unsigned type:2;
-        unsigned max_volt:10;
-        unsigned min_volt:10;
         unsigned max_cur:10;
+        unsigned min_volt:10;
+        unsigned max_volt:10;
+        unsigned type:2;
         
     }obj_var_sply;
     
@@ -154,10 +154,10 @@ union libtypec_battery_supply_src
     unsigned int battery_supply;
     struct battery_supply_bits
     {
-        unsigned type:2;
-        unsigned max_volt:10;
-        unsigned min_volt:10;
         unsigned max_pwr:10;
+        unsigned min_volt:10;
+        unsigned max_volt:10;
+        unsigned type:2;
     }obj_bat_sply;
     
 };
@@ -167,15 +167,15 @@ union libtypec_pps_src
     unsigned int spr_pps_supply;
     struct pps_supply_bits
     {
-        unsigned type:2;
-        unsigned pps_type:2;
-        unsigned pwr_ltd:1;
-        unsigned rsvd1:2;
-        unsigned max_volt:8;
-        unsigned rsvd2:1;
-        unsigned min_volt:8;
-        unsigned rsvd3:1;
         unsigned max_cur:7;
+        unsigned rsvd1:1;
+        unsigned min_volt:8;
+        unsigned rsvd2:1;
+        unsigned max_volt:8;
+        unsigned rsvd3:2;
+        unsigned pwr_ltd:1;
+        unsigned pps_type:2;
+        unsigned type:2;
     }obj_pps_sply;
     
 };
@@ -185,16 +185,16 @@ union libtypec_fixed_supply_snk
     unsigned int fixed_supply;
     struct fixed_sply_bits
     {
-        unsigned type:2;
-        unsigned drp:1;
-        unsigned higher_caps:1;
-        unsigned uncons_pwr:1;
-        unsigned usb_comm_cap:1;
-        unsigned drd:1;
-        unsigned fr_swp:2;
-        unsigned rsvd:3;
-        unsigned volt:10;
         unsigned opr_cur:10;
+        unsigned volt:10;
+        unsigned rsvd:3;
+        unsigned fr_swp:2;
+        unsigned drd:1;
+        unsigned usb_comm_cap:1;
+        unsigned uncons_pwr:1;
+        unsigned higher_caps:1;
+        unsigned drp:1;
+        unsigned type:2;
     }obj_fixed_supply;
     
 };
@@ -204,10 +204,10 @@ union libtypec_variable_sply_sink
     unsigned int var_sply_snk;
     struct var_supply_bits
     {
-        unsigned type:2;
-        unsigned max_volt:10;
-        unsigned min_volt:10;
         unsigned opr_cur:10;
+        unsigned min_volt:10;
+        unsigned max_volt:10;
+        unsigned type:2;
     }obj_var_sply;
     
 };
@@ -217,10 +217,10 @@ union libtypec_battery_sply_sink
     unsigned int battery_supply;
     struct battery_sply_bits
     {
-        unsigned type:2;
-        unsigned max_volt:10;
-        unsigned min_volt:10;
         unsigned opr_pwr:10;
+        unsigned min_volt:10;
+        unsigned max_volt:10;
+        unsigned type:2;
     }obj_bat_sply;
     
 };
@@ -230,14 +230,14 @@ union libtypec_pps_sink
     unsigned int spr_pps;
     struct spr_pps_bits
     {
-        unsigned type:2;
-        unsigned pps_type:2;
-        unsigned rsvd1:3;
-        unsigned max_volt:8;
-        unsigned rsvd2:1;
-        unsigned min_volt:8;
-        unsigned rsvd3:1;
         unsigned max_cur:7;
+        unsigned rsvd1:1;
+        unsigned min_volt:8;
+        unsigned rsvd2:1;
+        unsigned max_volt:8;
+        unsigned rsvd3:3;
+        unsigned pps_type:2;
+        unsigned type:2;
     }obj_spr_pps;
     
 };
@@ -279,6 +279,11 @@ union libtypec_pps_sink
 #define POWER_OP_MODE_PD 3
 #define POWER_OP_MODE_TC_1_5 4
 #define POWER_OP_MODE_TC_3 5
+
+#define PDO_FIXED 0
+#define PDO_BATTERY 1
+#define PDO_VARIABLE 2
+#define PDO_AUGMENTED 3
 
 int libtypec_init(char **session_info);
 int libtypec_exit(void);

--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -939,6 +939,7 @@ static int libtypec_sysfs_get_pdos_ops(int conn_num, int partner, int offset, in
 			pdo_data[num_pdos_read++] = get_programmable_supply_pdo(port_content,src_snk);
 
 		}
+
 		
 		
 	}

--- a/utils/lstypec.c
+++ b/utils/lstypec.c
@@ -37,6 +37,7 @@ struct libtypec_connector_cap_data conn_data;
 struct libtypec_connector_status conn_sts;
 struct libtypec_cable_property cable_prop;
 union libtypec_discovered_identity id;
+unsigned int* pdo_data;
 
 struct altmode_data am_data[64];
 char *session_info[LIBTYPEC_SESSION_MAX_INDEX];
@@ -518,6 +519,110 @@ void print_identity_data(int recipient, union libtypec_discovered_identity id, s
   }
 }
 
+void print_source_pdo_data(unsigned int* pdo_data, int num_pdos, int revision) {
+  for (int i = 0; i < num_pdos; i++) {
+    printf("    PDO%d: 0x%08x\n", i+1, pdo_data[i]);
+
+    if (verbose) {
+      if (revision == 0x20) {
+        switch((pdo_data[i] >> 30)) {
+          case PDO_FIXED:
+            print_vdo(pdo_data[i], 10, pd2p0_fixed_supply_src_fields, pd2p0_fixed_supply_src_field_desc);
+            break;
+          case PDO_BATTERY:
+            print_vdo(pdo_data[i], 4, pd2p0_battery_supply_src_fields, pd2p0_battery_supply_src_field_desc);
+            break;
+          case PDO_VARIABLE:
+            print_vdo(pdo_data[i], 4, pd2p0_variable_supply_src_fields, pd2p0_variable_supply_src_field_desc);
+            break;
+        }
+      } else if (revision == 0x30) {
+        switch((pdo_data[i] >> 30)) {
+          case PDO_FIXED:
+            print_vdo(pdo_data[i], 11, pd3p0_fixed_supply_src_fields, pd3p0_fixed_supply_src_field_desc);
+            break;
+          case PDO_BATTERY:
+            print_vdo(pdo_data[i], 4, pd3p0_battery_supply_src_fields, pd3p0_battery_supply_src_field_desc);
+            break;
+          case PDO_VARIABLE:
+            print_vdo(pdo_data[i], 4, pd3p0_variable_supply_src_fields, pd3p0_variable_supply_src_field_desc);
+            break;
+          case PDO_AUGMENTED:
+            print_vdo(pdo_data[i], 9, pd3p0_pps_apdo_src_fields, pd3p0_pps_apdo_src_field_desc);
+            break;
+        }
+      } else if (revision == 0x31) {
+        switch((pdo_data[i] >> 30)) {
+          case PDO_FIXED:
+            print_vdo(pdo_data[i], 12, pd3p1_fixed_supply_src_fields, pd3p1_fixed_supply_src_field_desc);
+            break;
+          case PDO_BATTERY:
+            print_vdo(pdo_data[i], 4, pd3p1_battery_supply_src_fields, pd3p1_battery_supply_src_field_desc);
+            break;
+          case PDO_VARIABLE:
+            print_vdo(pdo_data[i], 4, pd3p1_variable_supply_src_fields, pd3p1_variable_supply_src_field_desc);
+            break;
+          case PDO_AUGMENTED:
+            print_vdo(pdo_data[i], 9, pd3p1_pps_apdo_src_fields, pd3p1_pps_apdo_src_field_desc);
+            break;
+        }
+      }
+    }
+  }
+}
+
+void print_sink_pdo_data(unsigned int* pdo_data, int num_pdos, int revision) {
+  for (int i = 0; i < num_pdos; i++) {
+    printf("    PDO%d: 0x%08x\n", i+1, pdo_data[i]);
+
+    if (verbose) {
+      if (revision == 0x20) {
+        switch((pdo_data[i] >> 30)) {
+          case PDO_FIXED:
+            print_vdo(pdo_data[i], 9, pd2p0_fixed_supply_snk_fields, pd2p0_fixed_supply_snk_field_desc);
+            break;
+          case PDO_BATTERY:
+            print_vdo(pdo_data[i], 4, pd2p0_battery_supply_snk_fields, pd2p0_battery_supply_snk_field_desc);
+            break;
+          case PDO_VARIABLE:
+            print_vdo(pdo_data[i], 4, pd2p0_variable_supply_snk_fields, pd2p0_variable_supply_snk_field_desc);
+            break;
+        }
+      } else if (revision == 0x30) {
+        switch((pdo_data[i] >> 30)) {
+          case PDO_FIXED:
+            print_vdo(pdo_data[i], 10, pd3p0_fixed_supply_snk_fields, pd3p0_fixed_supply_snk_field_desc);
+            break;
+          case PDO_BATTERY:
+            print_vdo(pdo_data[i], 4, pd3p0_battery_supply_snk_fields, pd3p0_battery_supply_snk_field_desc);
+            break;
+          case PDO_VARIABLE:
+            print_vdo(pdo_data[i], 4, pd3p0_variable_supply_snk_fields, pd3p0_variable_supply_snk_field_desc);
+            break;
+          case PDO_AUGMENTED:
+            print_vdo(pdo_data[i], 8, pd3p0_pps_apdo_snk_fields, pd3p0_pps_apdo_snk_field_desc);
+            break;
+        }
+      } else if (revision == 0x31) {
+        switch((pdo_data[i] >> 30)) {
+          case PDO_FIXED:
+            print_vdo(pdo_data[i], 10, pd3p1_fixed_supply_snk_fields, pd3p1_fixed_supply_snk_field_desc);
+            break;
+          case PDO_BATTERY:
+            print_vdo(pdo_data[i], 4, pd3p1_battery_supply_snk_fields, pd3p1_battery_supply_snk_field_desc);
+            break;
+          case PDO_VARIABLE:
+            print_vdo(pdo_data[i], 4, pd3p1_variable_supply_snk_fields, pd3p1_variable_supply_snk_field_desc);
+            break;
+          case PDO_AUGMENTED:
+            print_vdo(pdo_data[i], 8, pd3p1_pps_apdo_snk_fields, pd3p1_pps_apdo_snk_field_desc);
+            break;
+        }
+      }
+    }
+  }
+}
+
 void lstypec_print(char *val, int type)
 {
     if (type == LSTYPEC_ERROR)
@@ -531,7 +636,7 @@ void lstypec_print(char *val, int type)
 
 int main(int argc, char *argv[])
 {
-  int ret, opt, num_modes;
+  int ret, opt, num_modes, num_pdos;
 
   // Process Command Args
   static const struct option options[] = {
@@ -577,6 +682,20 @@ int main(int argc, char *argv[])
     libtypec_get_conn_capability(i, &conn_data);
     print_conn_capability(conn_data);
 
+    // Connector PDOs
+    pdo_data = malloc(sizeof(int)*8);
+    ret = libtypec_get_pdos(i, 0, 0, &num_pdos, 1, 0, pdo_data);
+    if (ret > 0) {
+      printf("  Connector PDO Data (Source):\n");
+      print_source_pdo_data(pdo_data, num_pdos, get_cap_data.bcdPDVersion);
+    }
+    ret = libtypec_get_pdos(i, 0, 0, &num_pdos, 0, 0, pdo_data);
+    if (ret > 0) {
+      printf("  Connector PDO Data (Sink):\n");
+      print_source_pdo_data(pdo_data, num_pdos, get_cap_data.bcdPDVersion);
+    }
+    free(pdo_data);
+
     // Cable Properties
     ret = libtypec_get_cable_properties(i, &cable_prop);
     if (ret >= 0)
@@ -608,6 +727,18 @@ int main(int argc, char *argv[])
     if (ret >= 0) {
       print_identity_data(AM_SOP, id, conn_data);
     }
+    pdo_data = malloc(sizeof(int)*8);
+    ret = libtypec_get_pdos(i, 1, 0, &num_pdos, 1, 0, pdo_data);
+    if (ret > 0) {
+      printf("  Partner PDO Data (Source):\n");
+      print_source_pdo_data(pdo_data, num_pdos, conn_data.partner_rev);
+    }
+    ret = libtypec_get_pdos(i, 1, 0, &num_pdos, 0, 0, pdo_data);
+    if (ret > 0) {
+      printf("  Partner PDO Data (Sink):\n");
+      print_sink_pdo_data(pdo_data, num_pdos, conn_data.partner_rev);
+    }
+    free(pdo_data);
   }
 
   printf("\n");

--- a/utils/lstypec.h
+++ b/utils/lstypec.h
@@ -344,6 +344,111 @@ const char *pd2p0_ama_field_desc[][MAX_FIELDS] = {
   {NULL},
 };
 
+// USB PD 2.0 Fixed Supply PDO - Source (Section 6.4.1.2.3)
+const struct vdo_field pd2p0_fixed_supply_src_fields[] = {
+  {"Maximum Current in 10mA units", 1, 0, 0x3ff},
+  {"Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Peak Current", 1, 20, 0x3},
+  {"Reserved", 0, 22, 0x7},
+  {"Dual-Role Data", 1, 25, 0x1},
+  {"USB Communications Capable", 1, 26, 0x1},
+  {"Unconstrained Power", 1, 27, 0x1},
+  {"USB Suspend Supported", 1, 28, 0x1},
+  {"Daul-Role Power", 1, 29, 0x1},
+  {"Fixed supply", 1, 30, 0x3},
+};
+const char *pd2p0_fixed_supply_src_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 2.0 Variable Supply PDO - Source (Section 6.4.1.2.4)
+const struct vdo_field pd2p0_variable_supply_src_fields[] = {
+  {"Maximum Current in 10mA units", 1, 0, 0x3ff},
+  {"Minimum Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Maximum Voltage in 50mV units", 1, 20, 0x3ff},
+  {"Variable Supply", 1, 30, 0x3},
+};
+const char *pd2p0_variable_supply_src_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 2.0 Battery Supply PDO - Source (Section 6.4.1.2.5)
+const struct vdo_field pd2p0_battery_supply_src_fields[] = {
+  {"Maximum Allowable Power in 250mW units", 1, 0, 0x3ff},
+  {"Minimum Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Maximum Voltage in 50mV units", 1, 20, 0x3ff},
+  {"Battery", 1, 30, 0x3},
+};
+const char *pd2p0_battery_supply_src_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 2.0 Fixed Supply PDO - Sink (Section 6.4.1.3.1)
+const struct vdo_field pd2p0_fixed_supply_snk_fields[] = {
+  {"Operational Current in 10mA units", 1, 0, 0x3ff},
+  {"Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Reserved", 0, 20, 0x1f},
+  {"Dual-Role Data", 1, 25, 0x1},
+  {"USB Communications Capable", 1, 26, 0x1},
+  {"Unconstrained Power", 1, 27, 0x1},
+  {"Higher Capability", 1, 28, 0x1},
+  {"Daul-Role Power", 1, 29, 0x1},
+  {"Fixed supply", 1, 30, 0x3},
+};
+const char *pd2p0_fixed_supply_snk_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 2.0 Variable Supply PDO - Sink (Section 6.4.1.3.2)
+const struct vdo_field pd2p0_variable_supply_snk_fields[] = {
+  {"Operational Current in 10mA units", 1, 0, 0x3ff},
+  {"Minimum Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Maximum Voltage in 50mV units", 1, 20, 0x3ff},
+  {"Variable Supply", 1, 30, 0x3},
+};
+const char *pd2p0_variable_supply_snk_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 2.0 Battery Supply PDO - Sink (Section 6.4.1.3.3)
+const struct vdo_field pd2p0_battery_supply_snk_fields[] = {
+  {"Operational Power in 250mW units", 1, 0, 0x3ff},
+  {"Minimum Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Maximum Voltage in 50mV units", 1, 20, 0x3ff},
+  {"Battery", 1, 30, 0x3},
+};
+const char *pd2p0_battery_supply_snk_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
 
 // USB PD 3.0 ID Header VDO (Section 6.4.4.3.1.1)
 const struct vdo_field pd3p0_partner_id_header_fields[] = {
@@ -601,6 +706,161 @@ const char *pd3p0_dfp_field_desc[][MAX_FIELDS] = {
   {"Version 1.0", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
 };
 
+// USB PD 3.0 Fixed Supply PDO - Source (Section 6.4.1.2.2)
+const struct vdo_field pd3p0_fixed_supply_src_fields[] = {
+  {"Maximum Current in 10mA units", 1, 0, 0x3ff},
+  {"Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Peak Current", 1, 20, 0x3},
+  {"Reserved", 0, 22, 0x3},
+  {"Unchunked Extended Messages Supported", 0, 24, 0x1},
+  {"Dual-Role Data", 1, 25, 0x1},
+  {"USB Communications Capable", 1, 26, 0x1},
+  {"Unconstrained Power", 1, 27, 0x1},
+  {"USB Suspend Supported", 1, 28, 0x1},
+  {"Daul-Role Power", 1, 29, 0x1},
+  {"Fixed supply", 1, 30, 0x3},
+};
+const char *pd3p0_fixed_supply_src_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.0 Variable Supply PDO - Source (Section 6.4.1.2.3)
+const struct vdo_field pd3p0_variable_supply_src_fields[] = {
+  {"Maximum Current in 10mA units", 1, 0, 0x3ff},
+  {"Minimum Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Maximum Voltage in 50mV units", 1, 20, 0x3ff},
+  {"Variable Supply", 1, 30, 0x3},
+};
+const char *pd3p0_variable_supply_src_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.0 Battery Supply PDO - Source (Section 6.4.1.2.4)
+const struct vdo_field pd3p0_battery_supply_src_fields[] = {
+  {"Maximum Allowable Power in 250mW units", 1, 0, 0x3ff},
+  {"Minimum Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Maximum Voltage in 50mV units", 1, 20, 0x3ff},
+  {"Battery", 1, 30, 0x3},
+};
+const char *pd3p0_battery_supply_src_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.0 PPS APDO - Source (Section 6.4.1.2.5)
+const struct vdo_field pd3p0_pps_apdo_src_fields[] = {
+  {"Maximum Current in 50mA increments", 1, 0, 0x7f},
+  {"Reserved", 0, 7, 0x0},
+  {"Minimum Voltage in 100mV increments", 1, 8, 0xff},
+  {"Reserved", 0, 16, 0x0},
+  {"Maximum Voltage in 100mV increments", 1, 17, 0xff},
+  {"Reserved", 0, 25, 0x0},
+  {"PPS Power Limited", 1, 27, 0x1},
+  {"Programable Power Supply", 1, 28, 0x3},
+  {"Augmented Power Data Object", 1, 30, 0x3},
+};
+const char *pd3p0_pps_apdo_src_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.0 Fixed Supply PDO - Sink (Section 6.4.1.3.1)
+const struct vdo_field pd3p0_fixed_supply_snk_fields[] = {
+  {"Operational Current in 10mA units", 1, 0, 0x3ff},
+  {"Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Reserved", 0, 20, 0x7},
+  {"Fast Role Swap Required", 1, 23, 0x3},
+  {"Dual-Role Data", 1, 25, 0x1},
+  {"USB Communications Capable", 1, 26, 0x1},
+  {"Unconstrained Power", 1, 27, 0x1},
+  {"Higher Capability", 1, 28, 0x1},
+  {"Daul-Role Power", 1, 29, 0x1},
+  {"Fixed supply", 1, 30, 0x3},
+};
+const char *pd3p0_fixed_supply_snk_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {"Fast Swap not supported", "Default USB Power", "1.5A @ 5V", "3.0A @ 5V"},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.0 Variable Supply PDO - Sink (Section 6.4.1.3.2)
+const struct vdo_field pd3p0_variable_supply_snk_fields[] = {
+  {"Operational Current in 10mA units", 1, 0, 0x3ff},
+  {"Minimum Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Maximum Voltage in 50mV units", 1, 20, 0x3ff},
+  {"Variable Supply", 1, 30, 0x3},
+};
+const char *pd3p0_variable_supply_snk_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.0 Battery Supply PDO - Sink (Section 6.4.1.3.3)
+const struct vdo_field pd3p0_battery_supply_snk_fields[] = {
+  {"Operational Power in 250mW units", 1, 0, 0x3ff},
+  {"Minimum Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Maximum Voltage in 50mV units", 1, 20, 0x3ff},
+  {"Battery", 1, 30, 0x3},
+};
+const char *pd3p0_battery_supply_snk_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.0 PPS APDO - Sink (Section 6.4.1.3.4)
+const struct vdo_field pd3p0_pps_apdo_snk_fields[] = {
+  {"Maximum Current in 50mA increments", 1, 0, 0x7f},
+  {"Reserved", 0, 7, 0x0},
+  {"Minimum Voltage in 100mV increments", 1, 8, 0xff},
+  {"Reserved", 0, 16, 0x0},
+  {"Maximum Voltage in 100mV increments", 1, 17, 0xff},
+  {"Reserved", 0, 25, 0x7},
+  {"Programable Power Supply", 1, 28, 0x3},
+  {"Augmented Power Data Object", 1, 30, 0x3},
+};
+const char *pd3p0_pps_apdo_snk_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
 
 // USB PD 3.1 ID Header VDO (Section 6.4.4.3.1.1)
 const struct vdo_field pd3p1_partner_id_header_fields[] = {
@@ -834,6 +1094,163 @@ const char *pd3p1_dfp_field_desc[][MAX_FIELDS] = {
   {"Version 1.0", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved", "Reserved"},
 };
 
+// USB PD 3.1 Fixed Supply PDO - Source (Section 6.4.1.2.2)
+const struct vdo_field pd3p1_fixed_supply_src_fields[] = {
+  {"Maximum Current in 10mA units", 1, 0, 0x3ff},
+  {"Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Peak Current", 1, 20, 0x3},
+  {"Reserved", 0, 22, 0x1},
+  {"EPR Mode Capable", 1, 23, 0x1},
+  {"Unchunked Extended Messages Supported", 0, 24, 0x1},
+  {"Dual-Role Data", 1, 25, 0x1},
+  {"USB Communications Capable", 1, 26, 0x1},
+  {"Unconstrained Power", 1, 27, 0x1},
+  {"USB Suspend Supported", 1, 28, 0x1},
+  {"Daul-Role Power", 1, 29, 0x1},
+  {"Fixed supply", 1, 30, 0x3},
+};
+const char *pd3p1_fixed_supply_src_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.1 Variable Supply PDO - Source (Section 6.4.1.2.3)
+const struct vdo_field pd3p1_variable_supply_src_fields[] = {
+  {"Maximum Current in 10mA units", 1, 0, 0x3ff},
+  {"Minimum Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Maximum Voltage in 50mV units", 1, 20, 0x3ff},
+  {"Variable Supply", 1, 30, 0x3},
+};
+const char *pd3p1_variable_supply_src_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.1 Battery Supply PDO - Source (Section 6.4.1.2.4)
+const struct vdo_field pd3p1_battery_supply_src_fields[] = {
+  {"Maximum Allowable Power in 250mW units", 1, 0, 0x3ff},
+  {"Minimum Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Maximum Voltage in 50mV units", 1, 20, 0x3ff},
+  {"Battery", 1, 30, 0x3},
+};
+const char *pd3p1_battery_supply_src_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.1 PPS APDO - Source (Section 6.4.1.2.5)
+const struct vdo_field pd3p1_pps_apdo_src_fields[] = {
+  {"Maximum Current in 50mA increments", 1, 0, 0x7f},
+  {"Reserved", 0, 7, 0x0},
+  {"Minimum Voltage in 100mV increments", 1, 8, 0xff},
+  {"Reserved", 0, 16, 0x0},
+  {"Maximum Voltage in 100mV increments", 1, 17, 0xff},
+  {"Reserved", 0, 25, 0x0},
+  {"PPS Power Limited", 1, 27, 0x1},
+  {"SPR PPS", 1, 28, 0x3},
+  {"Augmented Power Data Object", 1, 30, 0x3},
+};
+const char *pd3p1_pps_apdo_src_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.1 Fixed Supply PDO - Sink (Section 6.4.1.3.1)
+const struct vdo_field pd3p1_fixed_supply_snk_fields[] = {
+  {"Operational Current in 10mA units", 1, 0, 0x3ff},
+  {"Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Reserved", 0, 20, 0x7},
+  {"Fast Role Swap Required", 1, 23, 0x3},
+  {"Dual-Role Data", 1, 25, 0x1},
+  {"USB Communications Capable", 1, 26, 0x1},
+  {"Unconstrained Power", 1, 27, 0x1},
+  {"Higher Capability", 1, 28, 0x1},
+  {"Daul-Role Power", 1, 29, 0x1},
+  {"Fixed supply", 1, 30, 0x3},
+};
+const char *pd3p1_fixed_supply_snk_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {"Fast Swap not supported", "Default USB Power", "1.5A @ 5V", "3.0A @ 5V"},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.1 Variable Supply PDO - Sink (Section 6.4.1.3.2)
+const struct vdo_field pd3p1_variable_supply_snk_fields[] = {
+  {"Operational Current in 10mA units", 1, 0, 0x3ff},
+  {"Minimum Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Maximum Voltage in 50mV units", 1, 20, 0x3ff},
+  {"Variable Supply", 1, 30, 0x3},
+};
+const char *pd3p1_variable_supply_snk_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.1 Battery Supply PDO - Sink (Section 6.4.1.3.3)
+const struct vdo_field pd3p1_battery_supply_snk_fields[] = {
+  {"Operational Power in 250mW units", 1, 0, 0x3ff},
+  {"Minimum Voltage in 50mV units", 1, 10, 0x3ff},
+  {"Maximum Voltage in 50mV units", 1, 20, 0x3ff},
+  {"Battery", 1, 30, 0x3},
+};
+const char *pd3p1_battery_supply_snk_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
+// USB PD 3.1 PPS APDO - Sink (Section 6.4.1.3.4)
+const struct vdo_field pd3p1_pps_apdo_snk_fields[] = {
+  {"Maximum Current in 50mA increments", 1, 0, 0x7f},
+  {"Reserved", 0, 7, 0x0},
+  {"Minimum Voltage in 100mV increments", 1, 8, 0xff},
+  {"Reserved", 0, 16, 0x0},
+  {"Maximum Voltage in 100mV increments", 1, 17, 0xff},
+  {"Reserved", 0, 25, 0x7},
+  {"SPR PPS", 1, 28, 0x3},
+  {"Augmented Power Data Object", 1, 30, 0x3},
+};
+const char *pd3p1_pps_apdo_snk_field_desc[][MAX_FIELDS] = {
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+  {NULL},
+};
+
 // Alternate mode VDOs
 const struct vdo_field dp_alt_mode_partner_fields[] = {
   {"Port Capability", 1, 0, 0x3},
@@ -943,6 +1360,10 @@ void print_cable_prop(struct libtypec_cable_property cable_prop, int conn_num);
 void print_alternate_mode_data(int recipient, uint32_t id_header, int num_modes, struct altmode_data *am_data);
 
 void print_identity_data(int recipient, union libtypec_discovered_identity id, struct libtypec_connector_cap_data conn_data);
+
+void print_source_pdo_data(unsigned int* pdo_data, int num_pdos, int revision);
+
+void print_sink_pdo_data(unsigned int* pdo_data, int num_pdos, int revision);
 
 void lstypec_print(char *val, int type);
 


### PR DESCRIPTION
Update lstypec to support parsing and displaying PDO information collected by libtypec.