### PR TITLE
Fix a file pointer leak on missing fclose in count_billbrd_if

### DIFF
--- a/libtypec_sysfs_ops.c
+++ b/libtypec_sysfs_ops.c
@@ -506,6 +506,7 @@ static int count_billbrd_if(const char *usb_path, const struct stat *sb, int typ
 			num_bb_if++;
 		}
 	}
+	fclose(fd);
 
 	return 0;
 }


### PR DESCRIPTION
A file is being opened but it is not being fclosed at the end of the function, leading to a file descriptor leak. Fix this by adding the missing fclose.