### PR TITLE
libtypec: allow use of older version of cmake 3.16.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25.2)
+cmake_minimum_required(VERSION 3.16.3)
 project(libtypec VERSION 0.5.0 DESCRIPTION "Library to interface with USB Type-C and USB Power Delivery class devices")
 
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25.2)
+cmake_minimum_required(VERSION 3.16.3)
 project(libtypec_utils VERSION 0.5.0)
 
 configure_file(libtypec_utils_config.h.in libtypec_utils_config.h)


### PR DESCRIPTION
Specify older versions of cmake, use 3.16.3 as this was tested on Ubuntu Focal 20.04 and works fine.