### PR TITLE
utils: fix some array overflow issues

### DIFF
--- a/utils/lstypec.c
+++ b/utils/lstypec.c
@@ -300,7 +300,7 @@ void print_alternate_mode_data(int recipient, uint32_t id_header, int num_modes,
           break;
         case 0xff01:
           if ((id_header & ACTIVE_CABLE_MASK) == ACTIVE_CABLE_COMP) {
-            print_vdo(am_data[i].vdo, 7, dp_alt_mode_active_cable_fields, dp_alt_mode_active_cable_field_desc);
+            print_vdo(am_data[i].vdo, 6, dp_alt_mode_active_cable_fields, dp_alt_mode_active_cable_field_desc);
           } else {
             get_vendor_string(vendor_id, sizeof(vendor_id), am_data[i].svid);
             printf("      SVID Decoding not supported for 0x%04x (%s)\n", am_data[i].svid, (vendor_id[0] == '\0' ? "unknown" : vendor_id));

--- a/utils/lstypec.h
+++ b/utils/lstypec.h
@@ -1118,6 +1118,7 @@ const char *pd3p1_fixed_supply_src_field_desc[][MAX_FIELDS] = {
   {NULL},
   {NULL},
   {NULL},
+  {NULL},
 };
 
 // USB PD 3.1 Variable Supply PDO - Source (Section 6.4.1.2.3)


### PR DESCRIPTION
There are two issues that cause array index overflows, one is that the call to print_vdo is passing an array size of 7 elements when in fact the arrays are only 6 elements. The second issue is that array pd3p1_fixed_supply_src_field_desc is 1 element too small. Fix these.