### PR TITLE
dbgfs: Fix infinite loop with some `GET_ALTERNATE_MODES` implementations

### DIFF
--- a/libtypec_dbgfs_ops.c
+++ b/libtypec_dbgfs_ops.c
@@ -193,7 +193,8 @@ static int libtypec_dbgfs_get_alternate_modes(int recipient, int conn_num, struc
 				alt_mode_data[i].svid 	 = buf[28] << 12 | buf[29] <<8 | buf[30] << 4 | buf[31];
 				alt_mode_data[i].vdo 	 = buf[24] << 12 | buf[25] <<8 | buf[26] << 4 | buf[27];	
 				
-				if(alt_mode_data[i].svid == 0)
+				if(alt_mode_data[i].svid == 0
+				|| (i > 0 && alt_mode_data[i].svid == alt_mode_data[i-1].svid && alt_mode_data[i].vdo == alt_mode_data[i-1].vdo))
 					break;
 			}
 			i++;


### PR DESCRIPTION
The UCSI implementation on my Lenovo ThinkPad X390 does not terminate the alt mode list properly; `GET_ALTERNATE_MODES` always returns the last alt mode on the list when called with an offset beyond the list size. This causes `libtypec_dbgfs_get_alternate_modes` to loop indefinitely until the `alt_mode_data` buffer overflows, causing a segfault.

This patch changes `libtypec_dbgfs_get_alternate_modes` to stop the alt mode iteration process if the same SVID and VDO are returned twice in a row, preventing that infinite loop.